### PR TITLE
Renamed to model-card and bump minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# CardFunc API Model
-Data model for CardFunc API.
+# PayFunc Card Tokenizing API Model
+Data model for PayFunc Card Tokenizing API.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
- "name": "@cardfunc/model",
- "version": "0.0.82",
- "description": "Javascript library containing the model for the CardFunc REST API.",
- "author": "CardFunc",
+ "name": "@payfunc/model-card",
+ "version": "0.1.0",
+ "description": "Javascript library containing the model for the PayFunc Card Tokenizing REST API.",
+ "author": "PayFunc",
  "license": "MIT",
  "repository": {
   "type": "git",
-  "url": "git+https://github.com/cardfunc/model"
+  "url": "git+https://github.com/payfunc/model-card"
  },
  "bugs": {
-  "url": "https://github.com/cardfunc/model/issues"
+  "url": "https://github.com/payfunc/model-card/issues"
  },
- "homepage": "https://github.com/cardfunc/model#readme",
+ "homepage": "https://github.com/payfunc/model-card#readme",
  "private": false,
  "main": "dist/index.js",
  "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Change
Moved cardfunc/model to the Payfunc organization and therefore also needed to change its name to model-card and change name and documentation from cardfunc to payfunc and model to model-card.

## Rationale
We want to hold everything in one organization to reduce administration.

## Impact
No impact on system.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
