### PR TITLE
Update authly; unpack multiple audiences.

### DIFF
--- a/Account.spec.ts
+++ b/Account.spec.ts
@@ -8,8 +8,10 @@ describe("Account", () => {
 			)
 		).toEqual({
 			aud: "production",
-			iat: 1581598581354,
+			iat: 1581598581,
 			id: "QYklGX_K",
 			iss: "CardFunc",
+			token:
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJDYXJkRnVuYyIsImlhdCI6MTU4MTU5ODU4MTM1NCwiYXVkIjoicHJvZHVjdGlvbiIsImlkIjoiUVlrbEdYX0sifQ.iyY_NTgzqHt1zJKmeEpm6yylWw1uLYLbW55KFMv7Q1z0hq90E9VfXhAgXbNQTQrj1ZNh1Xd_yQ6PMXQtT6CFMSAOsVCzvszk7r0_Big8yZSe8GjOIhpWdoyy55yPHDz5bh-9QffdDW_S3TGJGqwC9QBWRQXqJElKWJEY3nK1rfGFD-Ip7BY5MM3a4YpBeV6n2EIGtF4Rg5eM24WXuc9Kk1Buh-S2hwoXFV_pWu6zPWfSmWuIIOPiFE3w4FpzTu2yDvcE37R20yCYDD7P1tiA5rnNfy9CFFo5V-QlI_t3ybBOFf2_vRoKoT6Flm19fGJcRdWbulWXZQn9wQg2e654XA",
 		}))
 })

--- a/Authorization/index.spec.ts
+++ b/Authorization/index.spec.ts
@@ -52,7 +52,7 @@ describe("Authorization", () => {
 		const authorization = await model.Authorization.verify(token)
 		expect(authorization).toEqual({
 			iss: "card",
-			iat: 1572880391928,
+			iat: 1572880391,
 			id: "ljVsDiYBTxAg",
 			number: "axb01",
 			reference: "2be53d7b-bebb-4ba4-ad83-9564d54ff15a",
@@ -69,6 +69,8 @@ describe("Authorization", () => {
 			},
 			capture: [],
 			refund: [],
+			token:
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYXJkIiwiaWF0IjoxNTcyODgwMzkxOTI4LCJpZCI6ImxqVnNEaVlCVHhBZyIsIm51bWJlciI6ImF4YjAxIiwicmVmZXJlbmNlIjoiMmJlNTNkN2ItYmViYi00YmE0LWFkODMtOTU2NGQ1NGZmMTVhIiwiZGVzY3JpcHRvciI6IkEgdGVzdCB0cmFuc2FjdGlvbiIsImNyZWF0ZWQiOiIyMDE5LTExLTA0VDE1OjEzOjExKzAwOjAwIiwiYW1vdW50IjoxMzM3LjQyLCJjdXJyZW5jeSI6IlNFSyIsImNhcmQiOnsiaWQiOiJmWjIxSnRkYiIsInNjaGVtZSI6InZpc2EiLCJpaW4iOiI0MTAwMDAiLCJsYXN0NCI6IjAwMDAiLCJleHBpcmVzIjpbMSwyMF19LCJjYXB0dXJlIjpbXSwicmVmdW5kIjpbXX0.vlJpdaQi4hbnIPF3GkOY21YtlH4lKj9TobqdWL1VkC3Y7RoSju3GkzeP7U65J3Tlfc8SY5Ru435h8NWB2nrWJuHoxE4w_Bh-Z_4JYtHKxFFW7Z1GJ1ZX2o0NcTXfyvkfMy6yGimPtc9-0AiMykBzOZiQzZtDTu0zgJO0fpDNO-L-Wj_fY6MNDJ_TEDXKPQK_EURaUM0rurekEvQFDHyk1R4vFvxO9or3y5KUjzq7F8E9WY70ndEZXVyQ8O2RU7CIrzEWYp_J3MHIQTN65SQ6wNdoTN9a3L7M0auB_7P1kjQLRbwi8IHoKgMCocj3_zMQTl4h7ZDNlJs1gdmb607h3w",
 		})
 	})
 })

--- a/Card/Token.spec.ts
+++ b/Card/Token.spec.ts
@@ -65,6 +65,8 @@ describe("Card Token", () => {
 			aud: verifiedMinimalToken.aud,
 			iss: verifiedMinimalToken.iss,
 			iat: verifiedMinimalToken.iat,
+			token:
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYXJkZnVuYyIsImlhdCI6MTU5NTYwNDg5OTI0NiwiYXVkIjoiZGV2ZWxvcG1lbnQiLCJ0eXBlIjoic2luZ2xlIHVzZSIsImNhcmQiOiIxMjM0NTY3OCJ9.CW70uwZlIHh44hDeRZOCmPhzdGnFMFxjuDJayF16iDtMhOxuA9Xwvr8r5rJ7FYVJhrljyp87ntDSfJYMd2KJp9vA--AO6By7dDuk6REejT70AZnLiy3u8fMzT9gmKZYBZQPIID1HaGqwxX4yjcwoczavTQSaX0kgONibWe-UZ4ExWYqapgh4t7DfYLQrrgVqbHKUnuaqGr-5ehHhjtyglEySUH7UeexwqlHKR5updiqTe2wz61FHi2nBiZW_JvZVDAZbRkbci9J00fCWl3vl6VbIW9bGymfYSr3KXVfdEVaM1K1PPNsD8G5e0fJgwDm15JjJhGvkXqiFTXRM1cScdg",
 		}
 		expect(verifiedMinimalToken).toEqual(payloadedMinimalToken)
 		const originalTokenWithInfo: model.Card.Token = {
@@ -83,6 +85,8 @@ describe("Card Token", () => {
 			aud: verifiedWithInfo.aud,
 			iss: verifiedWithInfo.iss,
 			iat: verifiedWithInfo.iat,
+			token:
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYXJkZnVuYyIsImlhdCI6MTU5NTYwNDg5OTI2OSwiYXVkIjoiZGV2ZWxvcG1lbnQiLCJ0eXBlIjoic2luZ2xlIHVzZSIsImNhcmQiOiIxMjM0NTY3OCIsInNjaGVtZSI6InZpc2EiLCJpaW4iOiI0MTExMTEiLCJsYXN0NCI6IjExMTEiLCJleHBpcmVzIjpbMTIsMjZdfQ.JMA2FYtK8EVp2nV1BnLFoM1k2Cz8XTZEABBH7ZwGtfrp7sURb9QQPgXiO_luM4bRtqyVgtAUOxdp-KKS1IHGFmhga-9nh94Piv1qoR9XROSI9YJFn71N5m7x8qWZYh874KLEwrXWZge4WP1n1K_MtiEmzZw_yq1InOKaYqhfF3XMb1dTx0-k37_2RfKHLXPYuEdVy5ygRHONt2BcNsMkmV1Nh1YZ4ktPbAHynYWlqKEp1eLjJpMoSN7wLecZHLkzSenCHEDHLxVayqJBR48TxB3PV23CzqqEWlvg7EVY3io5lAiUJyXanAUCOF6lPlbNjR-BLQ2BmzcjJLEefxXqXA",
 		}
 		expect(verifiedWithInfo).toEqual(withInfoPayloaded)
 	})

--- a/Merchant/Key/KeyInfo.ts
+++ b/Merchant/Key/KeyInfo.ts
@@ -88,13 +88,13 @@ export namespace KeyInfo {
 	}
 	export async function unpack(
 		key: authly.Token | undefined,
-		audience: "private" | "public"
+		...audience: ("private" | "public" | "account")[]
 	): Promise<KeyInfo | undefined> {
 		let result
 		if (key) {
-			result = await authly.Verifier.create(audience).verify(key)
+			result = await authly.Verifier.create().verify(key, ...audience)
 			if (result && (result as any).option?.card) {
-				const cardKey = await authly.Verifier.create(audience).verify((result as any).option.card)
+				const cardKey = await authly.Verifier.create().verify((result as any).option.card, ...audience)
 				result = cardKey && model.Merchant.V1.Key.KeyInfo.is(cardKey) ? upgrade(cardKey) : undefined
 			} else {
 				if (model.Merchant.V1.Key.KeyInfo.is(result))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
- "name": "@cardfunc/model",
+ "name": "@payfunc/model-card",
  "version": "0.1.1",
  "lockfileVersion": 1,
  "requires": true,
@@ -2181,25 +2181,6 @@
     "fastq": "^1.6.0"
    }
   },
-  "@peculiar/asn1-schema": {
-   "version": "2.0.5",
-   "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.5.tgz",
-   "integrity": "sha512-VIKJjsgMkv+yyWx3C+D4xo6/NeCg0XFBgNlavtkxELijV+aKAq53du5KkOJbeZtm1nn9CinQKny2PqL8zCfpeA==",
-   "requires": {
-    "@types/asn1js": "^0.0.1",
-    "asn1js": "^2.0.26",
-    "pvtsutils": "^1.0.10",
-    "tslib": "^1.11.1"
-   }
-  },
-  "@peculiar/json-schema": {
-   "version": "1.1.10",
-   "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.10.tgz",
-   "integrity": "sha512-kbpnG9CkF1y6wwGkW7YtSA+yYK4X5uk4rAwsd1hxiaYE3Hkw2EsGlbGh/COkMLyFf+Fe830BoFiMSB3QnC/ItA==",
-   "requires": {
-    "tslib": "^1.11.1"
-   }
-  },
   "@simple-dom/interface": {
    "version": "1.4.0",
    "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -2222,14 +2203,6 @@
    "dev": true,
    "requires": {
     "@sinonjs/commons": "^1.7.0"
-   }
-  },
-  "@types/asn1js": {
-   "version": "0.0.1",
-   "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.1.tgz",
-   "integrity": "sha1-74uflwjLFjKhw6nNJ3F8qr55O8I=",
-   "requires": {
-    "@types/pvutils": "*"
    }
   },
   "@types/babel__core": {
@@ -2364,11 +2337,6 @@
    "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
    "integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
    "dev": true
-  },
-  "@types/pvutils": {
-   "version": "0.0.2",
-   "resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
-   "integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
   },
   "@types/stack-utils": {
    "version": "1.0.1",
@@ -2734,14 +2702,6 @@
     "safer-buffer": "~2.1.0"
    }
   },
-  "asn1js": {
-   "version": "2.0.26",
-   "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
-   "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
-   "requires": {
-    "pvutils": "^1.0.17"
-   }
-  },
   "assert-plus": {
    "version": "1.0.0",
    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2773,11 +2733,11 @@
    "dev": true
   },
   "authly": {
-   "version": "0.0.40",
-   "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.40.tgz",
-   "integrity": "sha512-iNROZR7Fg8AsrNeXgNmd9FUVPJ72oT7uPK6D6MaglTGA2m6t93UxobpJBHvO6sGhelY8AN24S24mluIuSd7obw==",
+   "version": "0.1.5",
+   "resolved": "https://registry.npmjs.org/authly/-/authly-0.1.5.tgz",
+   "integrity": "sha512-b/zidlH1p3QMHCoulPXPv/cnu+icqGZNlWiksosn2uOUoGwWpn0HztEK4EmFrCFGTGmi/IPWruwgtHa7WdPFZg==",
    "requires": {
-    "node-webcrypto-ossl": "2.1.0"
+    "cryptly": "0.0.10"
    }
   },
   "aws-sign2": {
@@ -3359,6 +3319,14 @@
       "isexe": "^2.0.0"
      }
     }
+   }
+  },
+  "cryptly": {
+   "version": "0.0.10",
+   "resolved": "https://registry.npmjs.org/cryptly/-/cryptly-0.0.10.tgz",
+   "integrity": "sha512-7OutyQ5BWlnmZQq2cryWNDEllVcN9YxH0RhMAblYq/0XPc+4+o2r87dMorBKFSndXlxqArq+63cdJh8w23MDHw==",
+   "requires": {
+    "node-webcrypto-ossl": "^1.0.48"
    }
   },
   "cssom": {
@@ -7625,8 +7593,7 @@
   "minimist": {
    "version": "1.2.5",
    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-   "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-   "dev": true
+   "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
   },
   "mixin-deep": {
    "version": "1.3.2",
@@ -7653,7 +7620,6 @@
    "version": "0.5.5",
    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-   "dev": true,
    "requires": {
     "minimist": "^1.2.5"
    }
@@ -7677,9 +7643,9 @@
    "dev": true
   },
   "nan": {
-   "version": "2.14.1",
-   "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-   "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+   "version": "2.14.2",
+   "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+   "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
   },
   "nanomatch": {
    "version": "1.2.13",
@@ -7755,22 +7721,14 @@
    }
   },
   "node-webcrypto-ossl": {
-   "version": "2.1.0",
-   "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.1.0.tgz",
-   "integrity": "sha512-diC2LLQKKo41XxrgdT2MmH4mxWNoeCwjS0+uSLfui3rCtxai8cdLLs0TKT0z9Mq8LZ4eMAkuU4FFmEOHk6CbsQ==",
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.49.tgz",
+   "integrity": "sha512-Zs73PeTWoUXUFicvAaxZC6ZyVCuq1Eg/Q4rYqiWyBY4eWIbZPFiRIi/KRM0A9GVKBPRNraaXsVmRAC83jEQ6nw==",
    "requires": {
-    "mkdirp": "^1.0.4",
-    "nan": "^2.14.1",
-    "pvtsutils": "^1.0.10",
-    "tslib": "^1.11.2",
-    "webcrypto-core": "^1.1.0"
-   },
-   "dependencies": {
-    "mkdirp": {
-     "version": "1.0.4",
-     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-    }
+    "mkdirp": "^0.5.5",
+    "nan": "^2.14.0",
+    "tslib": "^1.11.1",
+    "webcrypto-core": "^0.1.27"
    }
   },
   "normalize-package-data": {
@@ -8622,19 +8580,6 @@
    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
    "dev": true
-  },
-  "pvtsutils": {
-   "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
-   "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
-   "requires": {
-    "tslib": "^1.10.0"
-   }
-  },
-  "pvutils": {
-   "version": "1.0.17",
-   "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-   "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
   },
   "qs": {
    "version": "6.5.2",
@@ -10367,15 +10312,11 @@
    }
   },
   "webcrypto-core": {
-   "version": "1.1.1",
-   "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.1.1.tgz",
-   "integrity": "sha512-xK61sFRUyZdSAJG7+bJox36+Tnhxw1PaMbmrLLp30HNTJ4mffqsY2jUMlmGq6OOoej3WO/SsH5serzlzBMZ+jg==",
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.27.tgz",
+   "integrity": "sha512-r0MSFxvqaIjoqIKerm80P9+7n1dWBG88PYnshJk57J4uZuXlqNX8yQixrEIe3CGqrJ7xwfGM2SQGR4AlJYr02g==",
    "requires": {
-    "@peculiar/asn1-schema": "^2.0.1",
-    "@peculiar/json-schema": "^1.1.10",
-    "asn1js": "^2.0.26",
-    "pvtsutils": "^1.0.10",
-    "tslib": "^1.11.2"
+    "tslib": "^1.7.1"
    }
   },
   "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "clean": "rm -rf dist node_modules coverage"
  },
  "dependencies": {
-  "authly": "0.0.40",
+  "authly": "0.1.5",
   "gracely": "0.0.33",
   "isoly": "0.0.14"
  },

--- a/verify.ts
+++ b/verify.ts
@@ -1,21 +1,16 @@
 import * as authly from "authly"
 
 const productionVerifier = authly.Verifier.create(
-	"production",
 	authly.Algorithm.RS256(
 		"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArZFavKxpyvdY5hv1ZKegVXPfcoI0Tx4CIN7lAxdW80M9bROncr3tVngC48iWzbX/6ziw5xGwujXG/j1qSNIZlTOWx2imlWCl5doTSPb1yt0CX3pREdlBfR5RJGQHRhGpiQA51HO9wA9Y9OAq4kqaFcCkEpJeqvNjvXPJSTM97x4rksil63WalUFSjmWK6lEiQIo/cnLCi6l6MkSxYBZTwS6jGjGvBcYeNPwVHToRLl4Yz0KRdYFyMcO5wk9B6hQ+fA3rkhXezU0squlzPCBZnoyp2T+OqM/ztLuykVlQjVN5RNP89O02jcmsviYH3aRxtYmnaoRKlhXtBmiXmi873wIDAQAB"
 	)
 )
 const developmentVerifier = authly.Verifier.create(
-	"development",
 	authly.Algorithm.RS256(
 		"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzWkKmoMsdU6TRKeMYFlwwRxb7uuA3Xh1zsya9m9QLcF7FhSLxsaDF7hHWmbBLsKBCDT35hl8mIxOssQGcq5CvhntAmI7RgWExs/VgtyJK1uRxgUKS7wCuWxlB3akXY4f2UXcFn+wOqBdhh1yep726MvB/Jh4nDusXb5G4evVJLIrMKc8vvLqmEo9x8wuXz5s6qvIlHf6h7KLICNsX0ZCv6Tf3OYbZlfd0us+gQTvqhk+dj6P2UaUlQmsEAOerLvSKWDa1KNe0i58/aoDgC9FZGCmpg1mtPegQ09IAVgCaqQ6zqA1wPIWiOO89pWWne28tRCNYGvNY0eXUSG6qXv5LQIDAQAB"
 	)
 )
 
 export async function verify(token: authly.Token): Promise<authly.Payload | undefined> {
-	return (
-		(productionVerifier && (await productionVerifier.verify(token))) ||
-		(developmentVerifier && developmentVerifier.verify(token))
-	)
+	return (await productionVerifier?.verify(token, "production")) || developmentVerifier?.verify(token, "development")
 }


### PR DESCRIPTION
## Change
Update `authly` dependency and allow unpacking with multiple audiences, including `account`.


## Rationale
`card-tokenizer` needs to unpack keys with audience `account`. This requires an update to the unpack function. To check for multiple audiences in one call of the verify function an update to `authly` is required.

## Impact
Unpacking with multiple audiences has no impact except requiring less lines of code. Unpacking with audience `account` does not expose more information than the key itself exposes, as no encrypted fields get decrypted.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
