### PR TITLE
allow agent and account audiences on newer keys

### DIFF
--- a/Merchant/Configuration/Card/KeyInfo.ts
+++ b/Merchant/Configuration/Card/KeyInfo.ts
@@ -5,7 +5,7 @@ import { CategoryCode } from "../../CategoryCode"
 export interface KeyInfo {
 	descriptor?: string
 	country: isoly.CountryCode.Alpha2
-	acquirer: string
+	acquirer?: string
 	mid?: string
 	mcc?: CategoryCode
 	emv3d?: string
@@ -16,7 +16,7 @@ export namespace KeyInfo {
 			typeof value == "object" &&
 			(value.descriptor == undefined || typeof value.descriptor == "string") &&
 			isoly.CountryCode.Alpha2.is(value.country) &&
-			typeof value.acquirer == "string" &&
+			(value.acquirer == undefined || typeof value.acquirer == "string") &&
 			(value.mid == undefined || typeof value.mid == "string") &&
 			(value.mcc == undefined || CategoryCode.is(value.mcc)) &&
 			(value.emv3d == undefined || typeof value.emv3d == "string")
@@ -32,10 +32,11 @@ export namespace KeyInfo {
 							value.descriptor == undefined ||
 								typeof value.descriptor == "string" || { property: "descriptor", type: "string" },
 							isoly.CountryCode.Alpha2.is(value.country) || { property: "country", type: "isoly.CountryCode" },
-							typeof value.acquirer == "string" || {
-								property: "acquirer",
-								type: "encrypted model.Acquirer.Settings as string",
-							},
+							value.acquirer == undefined ||
+								typeof value.acquirer == "string" || {
+									property: "acquirer",
+									type: "encrypted model.Acquirer.Settings as string",
+								},
 							value.mid == undefined || typeof value.mid == "string" || { property: "mid", type: "string" },
 							value.mcc == undefined ||
 								CategoryCode.is(value.mcc) || { property: "mcc", type: "model.Merchant.CategoryCode" },

--- a/Merchant/Key/Audience.ts
+++ b/Merchant/Key/Audience.ts
@@ -1,0 +1,7 @@
+export type Audience = "agent" | "private" | "account" | "public"
+
+export namespace Audience {
+	export function is(value: Audience | any): value is Audience {
+		return value == "agent" || value == "private" || value == "account" || value == "public"
+	}
+}

--- a/Merchant/Key/KeyInfo.spec.ts
+++ b/Merchant/Key/KeyInfo.spec.ts
@@ -80,19 +80,4 @@ describe("Key", () => {
 			model.Merchant.Key.KeyInfo.is(await model.Merchant.Key.KeyInfo.unpack(testKeys.cardfunc.V1.public, "public"))
 		).toBeTruthy()
 	})
-	it("is missing id name", () =>
-		expect(
-			model.Merchant.Key.KeyInfo.is({
-				country: "GB",
-				acquirer: { protocol: "clearhaus", url: "https://example.com/", key: "secret-api-key" },
-				mcc: "1234",
-				bin: { visa: "1234", mastercard: "54321" },
-			})
-		).toBeFalsy())
-	it("flaw", () => {
-		expect(model.Merchant.Key.KeyInfo.flaw(key)).toEqual({
-			flaws: [],
-			type: "model.Merchant.Key.KeyInfo",
-		})
-	})
 })

--- a/Merchant/Key/KeyInfo.ts
+++ b/Merchant/Key/KeyInfo.ts
@@ -1,12 +1,13 @@
 import * as gracely from "gracely"
 import * as authly from "authly"
 import { KeyInfo as ConfigurationKeyInfo } from "../Configuration/KeyInfo"
+import { Audience } from "./Audience"
 import * as model from "../../index"
 
 export interface KeyInfo {
 	sub: string
 	iss: string
-	aud: "public" | "private"
+	aud: Audience | Audience[]
 	iat: number
 	name: string
 	url: string
@@ -20,7 +21,7 @@ export namespace KeyInfo {
 			typeof value == "object" &&
 			authly.Identifier.is(value.sub) &&
 			typeof value.iss == "string" &&
-			(value.aud == "public" || value.aud == "private") &&
+			(Audience.is(value.aud) || (Array.isArray(value.aud) && value.aud.every(Audience.is))) &&
 			typeof value.iat == "number" &&
 			typeof value.name == "string" &&
 			typeof value.url == "string" &&
@@ -41,11 +42,12 @@ export namespace KeyInfo {
 								condition: "Merchant identifier.",
 							},
 							typeof value.iss == "string" || { property: "iss", type: "string", condition: "Key issuer." },
-							typeof value.aud == "string" || {
-								property: "aud",
-								type: `"public" | "private"`,
-								condition: "Key audience.",
-							},
+							Audience.is(value.aud) ||
+								(Array.isArray(value.aud) && value.aud.every(Audience.is)) || {
+									property: "aud",
+									type: `"agent" | "account" | "public" | "private"`,
+									condition: "Key audience.",
+								},
 							typeof value.iat == "number" || { property: "iat", type: "number", condition: "Issued timestamp." },
 							typeof value.name == "string" || { property: "name", type: "string" },
 							typeof value.url == "string" || { property: "url", type: "string" },

--- a/Merchant/Key/index.ts
+++ b/Merchant/Key/index.ts
@@ -1,13 +1,14 @@
 import * as gracely from "gracely"
 import * as authly from "authly"
 import { Configuration } from "../Configuration"
+import { Audience as KeyAudience } from "./Audience"
 import { KeyInfo as KeyKeyInfo } from "./KeyInfo"
 import * as V1 from "../V1"
 
 export interface Key {
 	sub: string
 	iss: string
-	aud: "public" | "private"
+	aud: KeyAudience | KeyAudience[]
 	iat: number
 	name: string
 	url: string
@@ -21,7 +22,7 @@ export namespace Key {
 			typeof value == "object" &&
 			authly.Identifier.is(value.sub) &&
 			typeof value.iss == "string" &&
-			(value.aud == "public" || value.aud == "private") &&
+			(KeyAudience.is(value.aud) || (Array.isArray(value.aud) && value.aud.every(KeyAudience.is))) &&
 			typeof value.iat == "number" &&
 			typeof value.name == "string" &&
 			typeof value.url == "string" &&
@@ -42,11 +43,12 @@ export namespace Key {
 								condition: "Merchant identifier.",
 							},
 							typeof value.iss == "string" || { property: "iss", type: "string", condition: "Key issuer." },
-							typeof value.aud == "string" || {
-								property: "aud",
-								type: `"public" | "private"`,
-								condition: "Key audience.",
-							},
+							Audience.is(value.aud) ||
+								(Array.isArray(value.aud) && value.aud.every(Audience.is)) || {
+									property: "aud",
+									type: `"agent" | "account" | "public" | "private"`,
+									condition: "Key audience.",
+								},
 							typeof value.iat == "number" || { property: "iat", type: "number", condition: "Issued timestamp." },
 							typeof value.name == "string" || { property: "name", type: "string" },
 							typeof value.url == "string" || { property: "url", type: "string" },
@@ -86,6 +88,10 @@ export namespace Key {
 						emv3d: key.emv3d,
 					},
 			  }
+	}
+	export type Audience = KeyAudience
+	export namespace Audience {
+		export const is = KeyAudience.is
 	}
 	export type KeyInfo = KeyKeyInfo
 	export namespace KeyInfo {

--- a/Merchant/V1/Key/KeyInfo.ts
+++ b/Merchant/V1/Key/KeyInfo.ts
@@ -15,10 +15,10 @@ export namespace KeyInfo {
 	export function is(value: KeyInfo | any): value is KeyInfo {
 		return (
 			typeof value == "object" &&
-			authly.Identifier.is((value as any).sub) &&
-			typeof (value as any).iss == "string" &&
-			typeof (value as any).iat == "number" &&
-			((value as any).aud == "public" || (value as any).aud == "private") &&
+			authly.Identifier.is(value.sub) &&
+			typeof value.iss == "string" &&
+			typeof value.iat == "number" &&
+			(value.aud == "public" || value.aud == "private") &&
 			typeof value.name == "string" &&
 			typeof value.url == "string" &&
 			CardConfigurationKeyInfo.is(value)

--- a/Merchant/index.ts
+++ b/Merchant/index.ts
@@ -85,6 +85,10 @@ export namespace Merchant {
 		export const is = MerchantKey.is
 		export const flaw = MerchantKey.flaw
 		export const upgrade = MerchantKey.upgrade
+		export type Audience = MerchantKey.Audience
+		export namespace Audience {
+			export const is = MerchantKey.Audience.is
+		}
 		export type KeyInfo = MerchantKey.KeyInfo
 		export namespace KeyInfo {
 			export const is = MerchantKey.KeyInfo.is


### PR DESCRIPTION
## Change
Add audiences "agent" and "account" which is possible audiences in newer api-keys.

## Rationale
Need to be able to use new kind of audiences.

## Impact
Minimal, as it will only add support for some newer api-keys.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
