### PR TITLE
bump isoly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5460,9 +5460,9 @@
    "dev": true
   },
   "isoly": {
-   "version": "0.0.14",
-   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.14.tgz",
-   "integrity": "sha512-snNO1TsgvxzJ5RT5fvwlw6JFhQtj90W4W6X+jSlSZBg/Chxl++LF+PVxX6EeK3Nww7FvPGIdeukgX1ajIS1hDg=="
+   "version": "0.0.24",
+   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.24.tgz",
+   "integrity": "sha512-Uagzw4N2ZpJYqeFbzSIJ19x0vqfYVXALVbHH7tAyqe40xzs8P9LtWnbhXZz1nF5+sojBd97denLZc/naxsewcw=="
   },
   "isstream": {
    "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
  "dependencies": {
   "authly": "0.1.5",
   "gracely": "0.0.33",
-  "isoly": "0.0.14"
+  "isoly": "0.0.24"
  },
  "devDependencies": {
   "@babel/core": "^7.11.0",


### PR DESCRIPTION
## Change
Updated Isoly to contain isoly.Date.

## Rationale
isoly.Date missing in import chains going back to model-card repository.

## Impact
None, isoly.Date not used directly by model-card anywhere.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
