### PR TITLE
Change to es6 module

### DIFF
--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -4,9 +4,9 @@ import { Verifier } from "../Verifier"
 import { Expires } from "./Expires"
 
 export interface Token {
-	audience: "production" | "development"
-	created: isoly.DateTime
 	issuer: "card"
+	created: isoly.DateTime
+	audience: "production" | "development"
 	encrypted: string
 	expires: Expires
 	verification?: { type: "pares" | "method" | "challenge"; data?: string | { [property: string]: any } }
@@ -23,7 +23,7 @@ export namespace Token {
 			Expires.is(value.expires) &&
 			(value.verification == undefined ||
 				(typeof value.verification == "object" &&
-					((value.verification.type == "pares" && value.verification.data == undefined) ||
+					(value.verification.type == "pares" ||
 						value.verification.type == "method" ||
 						value.verification.type == "challenge") &&
 					(value.verification.data == undefined ||
@@ -42,6 +42,7 @@ export namespace Token {
 		)
 	}
 	const transformers = [
+		new authly.Property.Typeguard(is),
 		new authly.Property.Renamer({
 			encrypted: "enc",
 			verification: "ver",
@@ -51,12 +52,11 @@ export namespace Token {
 			created: "iat",
 		}),
 		new authly.Property.Converter({
-			issuer: {
+			iat: {
 				forward: value => (isoly.DateTime.is(value) ? isoly.DateTime.parse(value).getTime() : value),
 				backward: value => (typeof value == "number" ? isoly.DateTime.create(new Date(value)) : value),
 			},
 		}),
-		new authly.Property.Typeguard(is),
 	]
 	const verifier = Verifier.create<Token>().add(...transformers)
 	export async function verify(token: authly.Token): Promise<(Token & authly.Payload) | undefined> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,6 +2181,39 @@
     "fastq": "^1.6.0"
    }
   },
+  "@peculiar/asn1-schema": {
+   "version": "2.0.27",
+   "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
+   "integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
+   "requires": {
+    "@types/asn1js": "^2.0.0",
+    "asn1js": "^2.0.26",
+    "pvtsutils": "^1.1.1",
+    "tslib": "^2.0.3"
+   },
+   "dependencies": {
+    "tslib": {
+     "version": "2.1.0",
+     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    }
+   }
+  },
+  "@peculiar/json-schema": {
+   "version": "1.1.12",
+   "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+   "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+   "requires": {
+    "tslib": "^2.0.0"
+   },
+   "dependencies": {
+    "tslib": {
+     "version": "2.1.0",
+     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    }
+   }
+  },
   "@simple-dom/interface": {
    "version": "1.4.0",
    "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -2204,6 +2237,11 @@
    "requires": {
     "@sinonjs/commons": "^1.7.0"
    }
+  },
+  "@types/asn1js": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
+   "integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
   },
   "@types/babel__core": {
    "version": "7.1.8",
@@ -2702,6 +2740,14 @@
     "safer-buffer": "~2.1.0"
    }
   },
+  "asn1js": {
+   "version": "2.0.26",
+   "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+   "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+   "requires": {
+    "pvutils": "^1.0.17"
+   }
+  },
   "assert-plus": {
    "version": "1.0.0",
    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2733,11 +2779,11 @@
    "dev": true
   },
   "authly": {
-   "version": "0.1.5",
-   "resolved": "https://registry.npmjs.org/authly/-/authly-0.1.5.tgz",
-   "integrity": "sha512-b/zidlH1p3QMHCoulPXPv/cnu+icqGZNlWiksosn2uOUoGwWpn0HztEK4EmFrCFGTGmi/IPWruwgtHa7WdPFZg==",
+   "version": "0.2.2",
+   "resolved": "https://registry.npmjs.org/authly/-/authly-0.2.2.tgz",
+   "integrity": "sha512-9drm8Ro090eanNQLHeztq+9PpQE+njbWjRBouae2d8DNAaepjy4bL+SRTxpg49skFsf2DZ8TYsOrrnQh9XCSCQ==",
    "requires": {
-    "cryptly": "0.0.10"
+    "cryptly": "^0.1.2"
    }
   },
   "aws-sign2": {
@@ -3322,11 +3368,11 @@
    }
   },
   "cryptly": {
-   "version": "0.0.10",
-   "resolved": "https://registry.npmjs.org/cryptly/-/cryptly-0.0.10.tgz",
-   "integrity": "sha512-7OutyQ5BWlnmZQq2cryWNDEllVcN9YxH0RhMAblYq/0XPc+4+o2r87dMorBKFSndXlxqArq+63cdJh8w23MDHw==",
+   "version": "0.1.2",
+   "resolved": "https://registry.npmjs.org/cryptly/-/cryptly-0.1.2.tgz",
+   "integrity": "sha512-2ao63FSQiUxhKpwSx5kkLdCIpIPjdJ9FQ4M6Y1RBpmrq0978mSzN+lik21Oa6ygJNbPfnu692mwPW4L55hqUYw==",
    "requires": {
-    "node-webcrypto-ossl": "^1.0.48"
+    "node-webcrypto-ossl": "^2.1.2"
    }
   },
   "cssom": {
@@ -4913,9 +4959,9 @@
    "dev": true
   },
   "gracely": {
-   "version": "0.0.33",
-   "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.33.tgz",
-   "integrity": "sha512-CQnq3TbU2hvNg99ZFGjO/Luwjv54Iy7uM76DElzLCfRoeQR/a4hgCWJa6nyR1X2GXFuv5RNq/ENfrOzBOmIY3A=="
+   "version": "0.0.39",
+   "resolved": "https://registry.npmjs.org/gracely/-/gracely-0.0.39.tgz",
+   "integrity": "sha512-W/VQSouvvpu1vkNKslPKdIV0K3HI6TImE5qAJREhgzvO5b+HWrIxy+Y8tf5jM9p0w6fzmv7K0skee1jr1cSHvw=="
   },
   "graphql": {
    "version": "15.3.0",
@@ -5466,9 +5512,9 @@
    "dev": true
   },
   "isoly": {
-   "version": "0.0.24",
-   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.24.tgz",
-   "integrity": "sha512-Uagzw4N2ZpJYqeFbzSIJ19x0vqfYVXALVbHH7tAyqe40xzs8P9LtWnbhXZz1nF5+sojBd97denLZc/naxsewcw=="
+   "version": "0.0.26",
+   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.26.tgz",
+   "integrity": "sha512-WwRb1WIvGvjzu8U22MUaLVBPx56Qtrsm9znLgB6BMEVeP1MegnNKEI4Dsk/zNuWgckDCFnUsvjX+teT/onbgSg=="
   },
   "isstream": {
    "version": "0.1.2",
@@ -7599,7 +7645,8 @@
   "minimist": {
    "version": "1.2.5",
    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-   "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+   "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+   "dev": true
   },
   "mixin-deep": {
    "version": "1.3.2",
@@ -7626,6 +7673,7 @@
    "version": "0.5.5",
    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+   "dev": true,
    "requires": {
     "minimist": "^1.2.5"
    }
@@ -7727,14 +7775,27 @@
    }
   },
   "node-webcrypto-ossl": {
-   "version": "1.0.49",
-   "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.49.tgz",
-   "integrity": "sha512-Zs73PeTWoUXUFicvAaxZC6ZyVCuq1Eg/Q4rYqiWyBY4eWIbZPFiRIi/KRM0A9GVKBPRNraaXsVmRAC83jEQ6nw==",
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.1.2.tgz",
+   "integrity": "sha512-EkrrRUWW+2QrsZ8PZfPSaRlWg38WOv2/mZTcW0l2SbEYERJ0G3OkW6kBiTpzUtcM+2PBaspNRZPfpBvvLp0NTQ==",
    "requires": {
-    "mkdirp": "^0.5.5",
-    "nan": "^2.14.0",
-    "tslib": "^1.11.1",
-    "webcrypto-core": "^0.1.27"
+    "mkdirp": "^1.0.4",
+    "nan": "^2.14.1",
+    "pvtsutils": "^1.0.11",
+    "tslib": "^2.0.1",
+    "webcrypto-core": "^1.1.6"
+   },
+   "dependencies": {
+    "mkdirp": {
+     "version": "1.0.4",
+     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "tslib": {
+     "version": "2.1.0",
+     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    }
    }
   },
   "normalize-package-data": {
@@ -8586,6 +8647,26 @@
    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
    "dev": true
+  },
+  "pvtsutils": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.1.tgz",
+   "integrity": "sha512-Evbhe6L4Sxwu4SPLQ4LQZhgfWDQO3qa1lju9jM5cxsQp8vE10VipcSmo7hiJW48TmiHgVLgDtC2TL6/+ND+IVg==",
+   "requires": {
+    "tslib": "^2.0.3"
+   },
+   "dependencies": {
+    "tslib": {
+     "version": "2.1.0",
+     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    }
+   }
+  },
+  "pvutils": {
+   "version": "1.0.17",
+   "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+   "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
   },
   "qs": {
    "version": "6.5.2",
@@ -9882,7 +9963,8 @@
   "tslib": {
    "version": "1.13.0",
    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-   "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+   "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+   "dev": true
   },
   "tunnel-agent": {
    "version": "0.6.0",
@@ -10318,11 +10400,22 @@
    }
   },
   "webcrypto-core": {
-   "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.27.tgz",
-   "integrity": "sha512-r0MSFxvqaIjoqIKerm80P9+7n1dWBG88PYnshJk57J4uZuXlqNX8yQixrEIe3CGqrJ7xwfGM2SQGR4AlJYr02g==",
+   "version": "1.1.8",
+   "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.1.8.tgz",
+   "integrity": "sha512-hKnFXsqh0VloojNeTfrwFoRM4MnaWzH6vtXcaFcGjPEu+8HmBdQZnps3/2ikOFqS8bJN1RYr6mI2P/FJzyZnXg==",
    "requires": {
-    "tslib": "^1.7.1"
+    "@peculiar/asn1-schema": "^2.0.12",
+    "@peculiar/json-schema": "^1.1.12",
+    "asn1js": "^2.0.26",
+    "pvtsutils": "^1.0.11",
+    "tslib": "^2.0.1"
+   },
+   "dependencies": {
+    "tslib": {
+     "version": "2.1.0",
+     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+     "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    }
    }
   },
   "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
  "name": "@payfunc/model-card",
- "version": "0.1.12",
+ "version": "0.2.0",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
     "tsConfig": "tsconfig.test.json"
    }
   },
+  "transform": {
+   "^.+\\.(j|t)sx?$": "ts-jest"
+  },
+  "transformIgnorePatterns": [
+   "<rootDir>/node_modules/(?!(cryptly|authly|isoly|gracely)/.*)"
+  ],
   "testEnvironment": "node",
   "testRegex": "((\\.|/)(test|spec))(\\.|\\/.+)(jsx?|tsx?)$",
   "testPathIgnorePatterns": [
@@ -52,9 +58,9 @@
   "clean": "rm -rf dist node_modules coverage"
  },
  "dependencies": {
-  "authly": "0.1.5",
-  "gracely": "0.0.33",
-  "isoly": "0.0.24"
+  "authly": "0.2.2",
+  "gracely": "0.0.39",
+  "isoly": "0.0.26"
  },
  "devDependencies": {
   "@babel/core": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@payfunc/model-card",
- "version": "0.1.12",
+ "version": "0.2.0",
  "description": "Javascript library containing the model for the PayFunc Card Tokenizing REST API.",
  "author": "PayFunc",
  "license": "MIT",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
 	"compilerOptions": {
 		"target": "es2019",
-		"module": "commonjs",
+		"module": "es6",
+		"allowJs": true,
+		"esModuleInterop": true,
 		"noImplicitAny": true,
 		"removeComments": true,
 		"preserveConstEnums": true,


### PR DESCRIPTION
## Change
Compile to es6 module.
Bump imports to es6 module imports.
Fixed tests by recompiling es6 modules to commonjs.

## Rationale
es6 modules allow us to use treeshaking in modules import this.

## Impact
No impact as functionality is not changed.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
