### PR TITLE
epoch seconds to milliseconds

### DIFF
--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -54,7 +54,7 @@ export namespace Token {
 		new authly.Property.Converter({
 			iat: {
 				forward: value => (isoly.DateTime.is(value) ? isoly.DateTime.parse(value).getTime() : value),
-				backward: value => (typeof value == "number" ? isoly.DateTime.create(new Date(value)) : value),
+				backward: value => (typeof value == "number" ? isoly.DateTime.create(new Date(value * 1000)) : value),
 			},
 		}),
 	]


### PR DESCRIPTION
## Change
Converted seconds to milliseconds in JWT verification of Card.Token.

## Rationale
Date constructor uses epoch time in milliseconds, not seconds like JWT specification.

## Impact
No impact.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
