### PR TITLE
Bump jest 0.0 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,23 @@
     "@babel/helper-plugin-utils": "^7.10.1"
    }
   },
+  "@babel/plugin-syntax-import-meta": {
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+   "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/helper-plugin-utils": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+     "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+     "dev": true
+    }
+   }
+  },
   "@babel/plugin-syntax-json-strings": {
    "version": "7.8.3",
    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -1334,6 +1351,23 @@
    "dev": true,
    "requires": {
     "@babel/helper-plugin-utils": "^7.8.0"
+   }
+  },
+  "@babel/plugin-syntax-top-level-await": {
+   "version": "7.12.1",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+   "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/helper-plugin-utils": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+     "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+     "dev": true
+    }
    }
   },
   "@babel/template": {
@@ -1529,95 +1563,86 @@
    "dev": true
   },
   "@jest/console": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.0.1.tgz",
-   "integrity": "sha512-9t1KUe/93coV1rBSxMmBAOIK3/HVpwxArCA1CxskKyRiv6o8J70V8C/V3OJminVCTa2M0hQI9AWRd5wxu2dAHw==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+   "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
     "chalk": "^4.0.0",
-    "jest-message-util": "^26.0.1",
-    "jest-util": "^26.0.1",
+    "jest-message-util": "^26.6.2",
+    "jest-util": "^26.6.2",
     "slash": "^3.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
+    "@types/istanbul-reports": {
      "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     }
    }
   },
   "@jest/core": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.0.1.tgz",
-   "integrity": "sha512-Xq3eqYnxsG9SjDC+WLeIgf7/8KU6rddBxH+SCt18gEpOhAGYC/Mq+YbtlNcIdwjnnT+wDseXSbU0e5X84Y4jTQ==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+   "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
    "dev": true,
    "requires": {
-    "@jest/console": "^26.0.1",
-    "@jest/reporters": "^26.0.1",
-    "@jest/test-result": "^26.0.1",
-    "@jest/transform": "^26.0.1",
-    "@jest/types": "^26.0.1",
+    "@jest/console": "^26.6.2",
+    "@jest/reporters": "^26.6.2",
+    "@jest/test-result": "^26.6.2",
+    "@jest/transform": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
     "ansi-escapes": "^4.2.1",
     "chalk": "^4.0.0",
     "exit": "^0.1.2",
     "graceful-fs": "^4.2.4",
-    "jest-changed-files": "^26.0.1",
-    "jest-config": "^26.0.1",
-    "jest-haste-map": "^26.0.1",
-    "jest-message-util": "^26.0.1",
+    "jest-changed-files": "^26.6.2",
+    "jest-config": "^26.6.3",
+    "jest-haste-map": "^26.6.2",
+    "jest-message-util": "^26.6.2",
     "jest-regex-util": "^26.0.0",
-    "jest-resolve": "^26.0.1",
-    "jest-resolve-dependencies": "^26.0.1",
-    "jest-runner": "^26.0.1",
-    "jest-runtime": "^26.0.1",
-    "jest-snapshot": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jest-validate": "^26.0.1",
-    "jest-watcher": "^26.0.1",
+    "jest-resolve": "^26.6.2",
+    "jest-resolve-dependencies": "^26.6.3",
+    "jest-runner": "^26.6.3",
+    "jest-runtime": "^26.6.3",
+    "jest-snapshot": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "jest-validate": "^26.6.2",
+    "jest-watcher": "^26.6.2",
     "micromatch": "^4.0.2",
     "p-each-series": "^2.1.0",
     "rimraf": "^3.0.0",
@@ -1625,326 +1650,386 @@
     "strip-ansi": "^6.0.0"
    },
    "dependencies": {
+    "@jest/transform": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+     "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+     "dev": true,
+     "requires": {
+      "@babel/core": "^7.1.0",
+      "@jest/types": "^26.6.2",
+      "babel-plugin-istanbul": "^6.0.0",
+      "chalk": "^4.0.0",
+      "convert-source-map": "^1.4.0",
+      "fast-json-stable-stringify": "^2.0.0",
+      "graceful-fs": "^4.2.4",
+      "jest-haste-map": "^26.6.2",
+      "jest-regex-util": "^26.0.0",
+      "jest-util": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "pirates": "^4.0.1",
+      "slash": "^3.0.0",
+      "source-map": "^0.6.1",
+      "write-file-atomic": "^3.0.0"
+     }
+    },
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
+    "@types/istanbul-reports": {
      "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
-    },
-    "strip-ansi": {
-     "version": "6.0.0",
-     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "ansi-regex": "^5.0.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
-   }
-  },
-  "@jest/environment": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.0.1.tgz",
-   "integrity": "sha512-xBDxPe8/nx251u0VJ2dFAFz2H23Y98qdIaNwnMK6dFQr05jc+Ne/2np73lOAx+5mSBO/yuQldRrQOf6hP1h92g==",
-   "dev": true,
-   "requires": {
-    "@jest/fake-timers": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "jest-mock": "^26.0.1"
-   },
-   "dependencies": {
-    "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
-     "dev": true,
-     "requires": {
-      "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
-      "@types/yargs": "^15.0.0",
-      "chalk": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
      }
-    }
-   }
-  },
-  "@jest/fake-timers": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.0.1.tgz",
-   "integrity": "sha512-Oj/kCBnTKhm7CR+OJSjZty6N1bRDr9pgiYQr4wY221azLz5PHi08x/U+9+QpceAYOWheauLP8MhtSVFrqXQfhg==",
-   "dev": true,
-   "requires": {
-    "@jest/types": "^26.0.1",
-    "@sinonjs/fake-timers": "^6.0.1",
-    "jest-message-util": "^26.0.1",
-    "jest-mock": "^26.0.1",
-    "jest-util": "^26.0.1"
-   },
-   "dependencies": {
-    "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
-     "dev": true,
-     "requires": {
-      "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
-      "@types/yargs": "^15.0.0",
-      "chalk": "^4.0.0"
-     }
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
-   }
-  },
-  "@jest/globals": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.0.1.tgz",
-   "integrity": "sha512-iuucxOYB7BRCvT+TYBzUqUNuxFX1hqaR6G6IcGgEqkJ5x4htNKo1r7jk1ji9Zj8ZMiMw0oB5NaA7k5Tx6MVssA==",
-   "dev": true,
-   "requires": {
-    "@jest/environment": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "expect": "^26.0.1"
-   },
-   "dependencies": {
-    "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
-     "dev": true,
-     "requires": {
-      "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
-      "@types/yargs": "^15.0.0",
-      "chalk": "^4.0.0"
-     }
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
-   }
-  },
-  "@jest/reporters": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.0.1.tgz",
-   "integrity": "sha512-NWWy9KwRtE1iyG/m7huiFVF9YsYv/e+mbflKRV84WDoJfBqUrNRyDbL/vFxQcYLl8IRqI4P3MgPn386x76Gf2g==",
-   "dev": true,
-   "requires": {
-    "@bcoe/v8-coverage": "^0.2.3",
-    "@jest/console": "^26.0.1",
-    "@jest/test-result": "^26.0.1",
-    "@jest/transform": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "chalk": "^4.0.0",
-    "collect-v8-coverage": "^1.0.0",
-    "exit": "^0.1.2",
-    "glob": "^7.1.2",
-    "graceful-fs": "^4.2.4",
-    "istanbul-lib-coverage": "^3.0.0",
-    "istanbul-lib-instrument": "^4.0.0",
-    "istanbul-lib-report": "^3.0.0",
-    "istanbul-lib-source-maps": "^4.0.0",
-    "istanbul-reports": "^3.0.2",
-    "jest-haste-map": "^26.0.1",
-    "jest-resolve": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jest-worker": "^26.0.0",
-    "node-notifier": "^7.0.0",
-    "slash": "^3.0.0",
-    "source-map": "^0.6.0",
-    "string-length": "^4.0.1",
-    "terminal-link": "^2.0.0",
-    "v8-to-istanbul": "^4.1.3"
-   },
-   "dependencies": {
-    "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
-     "dev": true,
-     "requires": {
-      "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
-      "@types/yargs": "^15.0.0",
-      "chalk": "^4.0.0"
-     }
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
-     "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
     },
     "source-map": {
      "version": "0.6.1",
      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
      "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    }
+   }
+  },
+  "@jest/environment": {
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+   "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+   "dev": true,
+   "requires": {
+    "@jest/fake-timers": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
+    "jest-mock": "^26.6.2"
+   },
+   "dependencies": {
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
      }
     }
    }
   },
+  "@jest/fake-timers": {
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+   "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+   "dev": true,
+   "requires": {
+    "@jest/types": "^26.6.2",
+    "@sinonjs/fake-timers": "^6.0.1",
+    "@types/node": "*",
+    "jest-message-util": "^26.6.2",
+    "jest-mock": "^26.6.2",
+    "jest-util": "^26.6.2"
+   },
+   "dependencies": {
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    }
+   }
+  },
+  "@jest/globals": {
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+   "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+   "dev": true,
+   "requires": {
+    "@jest/environment": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "expect": "^26.6.2"
+   },
+   "dependencies": {
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
+     }
+    }
+   }
+  },
+  "@jest/reporters": {
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+   "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+   "dev": true,
+   "requires": {
+    "@bcoe/v8-coverage": "^0.2.3",
+    "@jest/console": "^26.6.2",
+    "@jest/test-result": "^26.6.2",
+    "@jest/transform": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "chalk": "^4.0.0",
+    "collect-v8-coverage": "^1.0.0",
+    "exit": "^0.1.2",
+    "glob": "^7.1.2",
+    "graceful-fs": "^4.2.4",
+    "istanbul-lib-coverage": "^3.0.0",
+    "istanbul-lib-instrument": "^4.0.3",
+    "istanbul-lib-report": "^3.0.0",
+    "istanbul-lib-source-maps": "^4.0.0",
+    "istanbul-reports": "^3.0.2",
+    "jest-haste-map": "^26.6.2",
+    "jest-resolve": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "jest-worker": "^26.6.2",
+    "node-notifier": "^8.0.0",
+    "slash": "^3.0.0",
+    "source-map": "^0.6.0",
+    "string-length": "^4.0.1",
+    "terminal-link": "^2.0.0",
+    "v8-to-istanbul": "^7.0.0"
+   },
+   "dependencies": {
+    "@jest/transform": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+     "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+     "dev": true,
+     "requires": {
+      "@babel/core": "^7.1.0",
+      "@jest/types": "^26.6.2",
+      "babel-plugin-istanbul": "^6.0.0",
+      "chalk": "^4.0.0",
+      "convert-source-map": "^1.4.0",
+      "fast-json-stable-stringify": "^2.0.0",
+      "graceful-fs": "^4.2.4",
+      "jest-haste-map": "^26.6.2",
+      "jest-regex-util": "^26.0.0",
+      "jest-util": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "pirates": "^4.0.1",
+      "slash": "^3.0.0",
+      "source-map": "^0.6.1",
+      "write-file-atomic": "^3.0.0"
+     }
+    },
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
+     }
+    },
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
+     }
+    },
+    "source-map": {
+     "version": "0.6.1",
+     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+     "dev": true
+    }
+   }
+  },
   "@jest/source-map": {
-   "version": "26.0.0",
-   "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.0.0.tgz",
-   "integrity": "sha512-S2Z+Aj/7KOSU2TfW0dyzBze7xr95bkm5YXNUqqCek+HE0VbNNSNzrRwfIi5lf7wvzDTSS0/ib8XQ1krFNyYgbQ==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+   "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
    "dev": true,
    "requires": {
     "callsites": "^3.0.0",
@@ -1961,71 +2046,133 @@
    }
   },
   "@jest/test-result": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.0.1.tgz",
-   "integrity": "sha512-oKwHvOI73ICSYRPe8WwyYPTtiuOAkLSbY8/MfWF3qDEd/sa8EDyZzin3BaXTqufir/O/Gzea4E8Zl14XU4Mlyg==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+   "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
    "dev": true,
    "requires": {
-    "@jest/console": "^26.0.1",
-    "@jest/types": "^26.0.1",
+    "@jest/console": "^26.6.2",
+    "@jest/types": "^26.6.2",
     "@types/istanbul-lib-coverage": "^2.0.0",
     "collect-v8-coverage": "^1.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
      }
     }
    }
   },
   "@jest/test-sequencer": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.0.1.tgz",
-   "integrity": "sha512-ssga8XlwfP8YjbDcmVhwNlrmblddMfgUeAkWIXts1V22equp2GMIHxm7cyeD5Q/B0ZgKPK/tngt45sH99yLLGg==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+   "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
    "dev": true,
    "requires": {
-    "@jest/test-result": "^26.0.1",
+    "@jest/test-result": "^26.6.2",
     "graceful-fs": "^4.2.4",
-    "jest-haste-map": "^26.0.1",
-    "jest-runner": "^26.0.1",
-    "jest-runtime": "^26.0.1"
+    "jest-haste-map": "^26.6.2",
+    "jest-runner": "^26.6.3",
+    "jest-runtime": "^26.6.3"
+   },
+   "dependencies": {
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
+     }
+    },
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
+     }
+    }
    }
   },
   "@jest/transform": {
@@ -2188,9 +2335,9 @@
    "dev": true
   },
   "@sinonjs/commons": {
-   "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-   "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+   "version": "1.8.2",
+   "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+   "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
    "dev": true,
    "requires": {
     "type-detect": "4.0.8"
@@ -2333,15 +2480,15 @@
    "dev": true
   },
   "@types/prettier": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
-   "integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
+   "version": "2.1.6",
+   "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
+   "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
    "dev": true
   },
   "@types/stack-utils": {
-   "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-   "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+   "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
    "dev": true
   },
   "@types/unist": {
@@ -2501,15 +2648,15 @@
    }
   },
   "abab": {
-   "version": "2.0.3",
-   "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-   "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+   "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
    "dev": true
   },
   "acorn": {
-   "version": "7.2.0",
-   "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-   "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+   "version": "7.4.1",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+   "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
    "dev": true
   },
   "acorn-globals": {
@@ -2529,9 +2676,9 @@
    "dev": true
   },
   "acorn-walk": {
-   "version": "7.1.1",
-   "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-   "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+   "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
    "dev": true
   },
   "ajv": {
@@ -2747,9 +2894,9 @@
    "dev": true
   },
   "aws4": {
-   "version": "1.10.0",
-   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-   "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+   "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
    "dev": true
   },
   "babel-eslint": {
@@ -3113,6 +3260,12 @@
     }
    }
   },
+  "cjs-module-lexer": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+   "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+   "dev": true
+  },
   "class-utils": {
    "version": "0.3.6",
    "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3154,23 +3307,6 @@
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
     "wrap-ansi": "^6.2.0"
-   },
-   "dependencies": {
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "strip-ansi": {
-     "version": "6.0.0",
-     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-     "dev": true,
-     "requires": {
-      "ansi-regex": "^5.0.0"
-     }
-    }
    }
   },
   "co": {
@@ -3394,9 +3530,9 @@
    "dev": true
   },
   "decimal.js": {
-   "version": "10.2.0",
-   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-   "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+   "version": "10.2.1",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+   "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
    "dev": true
   },
   "decode-uri-component": {
@@ -3568,6 +3704,12 @@
    "integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ==",
    "dev": true
   },
+  "emittery": {
+   "version": "0.7.2",
+   "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+   "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+   "dev": true
+  },
   "emoji-regex": {
    "version": "8.0.0",
    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3638,9 +3780,9 @@
    "dev": true
   },
   "escodegen": {
-   "version": "1.14.2",
-   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.2.tgz",
-   "integrity": "sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==",
+   "version": "1.14.3",
+   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+   "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
    "dev": true,
    "requires": {
     "esprima": "^4.0.1",
@@ -4457,65 +4599,46 @@
    }
   },
   "expect": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/expect/-/expect-26.0.1.tgz",
-   "integrity": "sha512-QcCy4nygHeqmbw564YxNbHTJlXh47dVID2BUP52cZFpLU9zHViMFK6h07cC1wf7GYCTIigTdAXhVua8Yl1FkKg==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+   "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "ansi-styles": "^4.0.0",
-    "jest-get-type": "^26.0.0",
-    "jest-matcher-utils": "^26.0.1",
-    "jest-message-util": "^26.0.1",
+    "jest-get-type": "^26.3.0",
+    "jest-matcher-utils": "^26.6.2",
+    "jest-message-util": "^26.6.2",
     "jest-regex-util": "^26.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
     }
    }
   },
@@ -4816,6 +4939,12 @@
    "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
    "dev": true
   },
+  "get-caller-file": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+   "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+   "dev": true
+  },
   "get-package-type": {
    "version": "0.1.0",
    "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4958,13 +5087,27 @@
    "dev": true
   },
   "har-validator": {
-   "version": "5.1.3",
-   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-   "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+   "version": "5.1.5",
+   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+   "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
    "dev": true,
    "requires": {
-    "ajv": "^6.5.5",
+    "ajv": "^6.12.3",
     "har-schema": "^2.0.0"
+   },
+   "dependencies": {
+    "ajv": {
+     "version": "6.12.6",
+     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+     "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+     "dev": true,
+     "requires": {
+      "fast-deep-equal": "^3.1.1",
+      "fast-json-stable-stringify": "^2.0.0",
+      "json-schema-traverse": "^0.4.1",
+      "uri-js": "^4.2.2"
+     }
+    }
    }
   },
   "has": {
@@ -5253,6 +5396,15 @@
     "ci-info": "^2.0.0"
    }
   },
+  "is-core-module": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+   "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+   "dev": true,
+   "requires": {
+    "has": "^1.0.3"
+   }
+  },
   "is-data-descriptor": {
    "version": "0.1.4",
    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -5305,9 +5457,9 @@
    }
   },
   "is-docker": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-   "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+   "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
    "dev": true,
    "optional": true
   },
@@ -5511,17 +5663,6 @@
     "istanbul-lib-coverage": "^3.0.0",
     "make-dir": "^3.0.0",
     "supports-color": "^7.1.0"
-   },
-   "dependencies": {
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
    }
   },
   "istanbul-lib-source-maps": {
@@ -5536,12 +5677,12 @@
    },
    "dependencies": {
     "debug": {
-     "version": "4.1.1",
-     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+     "version": "4.3.1",
+     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+     "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
      "dev": true,
      "requires": {
-      "ms": "^2.1.1"
+      "ms": "2.1.2"
      }
     },
     "ms": {
@@ -5569,121 +5710,106 @@
    }
   },
   "jest": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest/-/jest-26.0.1.tgz",
-   "integrity": "sha512-29Q54kn5Bm7ZGKIuH2JRmnKl85YRigp0o0asTc6Sb6l2ch1DCXIeZTLLFy9ultJvhkTqbswF5DEx4+RlkmCxWg==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+   "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
    "dev": true,
    "requires": {
-    "@jest/core": "^26.0.1",
+    "@jest/core": "^26.6.3",
     "import-local": "^3.0.2",
-    "jest-cli": "^26.0.1"
+    "jest-cli": "^26.6.3"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "jest-cli": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.0.1.tgz",
-     "integrity": "sha512-pFLfSOBcbG9iOZWaMK4Een+tTxi/Wcm34geqZEqrst9cZDkTQ1LZ2CnBrTlHWuYAiTMFr0EQeK52ScyFU8wK+w==",
+     "version": "26.6.3",
+     "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+     "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
      "dev": true,
      "requires": {
-      "@jest/core": "^26.0.1",
-      "@jest/test-result": "^26.0.1",
-      "@jest/types": "^26.0.1",
+      "@jest/core": "^26.6.3",
+      "@jest/test-result": "^26.6.2",
+      "@jest/types": "^26.6.2",
       "chalk": "^4.0.0",
       "exit": "^0.1.2",
       "graceful-fs": "^4.2.4",
       "import-local": "^3.0.2",
       "is-ci": "^2.0.0",
-      "jest-config": "^26.0.1",
-      "jest-util": "^26.0.1",
-      "jest-validate": "^26.0.1",
+      "jest-config": "^26.6.3",
+      "jest-util": "^26.6.2",
+      "jest-validate": "^26.6.2",
       "prompts": "^2.0.1",
-      "yargs": "^15.3.1"
+      "yargs": "^15.4.1"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     }
    }
   },
   "jest-changed-files": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.0.1.tgz",
-   "integrity": "sha512-q8LP9Sint17HaE2LjxQXL+oYWW/WeeXMPE2+Op9X3mY8IEGFVc14xRxFjUuXUbcPAlDLhtWdIEt59GdQbn76Hw==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+   "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "execa": "^4.0.0",
     "throat": "^5.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "cross-spawn": {
@@ -5698,9 +5824,9 @@
      }
     },
     "execa": {
-     "version": "4.0.2",
-     "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-     "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+     "version": "4.1.0",
+     "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+     "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
      "dev": true,
      "requires": {
       "cross-spawn": "^7.0.0",
@@ -5715,9 +5841,9 @@
      }
     },
     "get-stream": {
-     "version": "5.1.0",
-     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-     "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+     "version": "5.2.0",
+     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+     "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
      "dev": true,
      "requires": {
       "pump": "^3.0.0"
@@ -5758,108 +5884,224 @@
      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
      "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
     }
    }
   },
   "jest-config": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.0.1.tgz",
-   "integrity": "sha512-9mWKx2L1LFgOXlDsC4YSeavnblN6A4CPfXFiobq+YYLaBMymA/SczN7xYTSmLaEYHZOcB98UdoN4m5uNt6tztg==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+   "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
    "dev": true,
    "requires": {
     "@babel/core": "^7.1.0",
-    "@jest/test-sequencer": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "babel-jest": "^26.0.1",
+    "@jest/test-sequencer": "^26.6.3",
+    "@jest/types": "^26.6.2",
+    "babel-jest": "^26.6.3",
     "chalk": "^4.0.0",
     "deepmerge": "^4.2.2",
     "glob": "^7.1.1",
     "graceful-fs": "^4.2.4",
-    "jest-environment-jsdom": "^26.0.1",
-    "jest-environment-node": "^26.0.1",
-    "jest-get-type": "^26.0.0",
-    "jest-jasmine2": "^26.0.1",
+    "jest-environment-jsdom": "^26.6.2",
+    "jest-environment-node": "^26.6.2",
+    "jest-get-type": "^26.3.0",
+    "jest-jasmine2": "^26.6.3",
     "jest-regex-util": "^26.0.0",
-    "jest-resolve": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jest-validate": "^26.0.1",
+    "jest-resolve": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "jest-validate": "^26.6.2",
     "micromatch": "^4.0.2",
-    "pretty-format": "^26.0.1"
+    "pretty-format": "^26.6.2"
    },
    "dependencies": {
+    "@jest/transform": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+     "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+     "dev": true,
+     "requires": {
+      "@babel/core": "^7.1.0",
+      "@jest/types": "^26.6.2",
+      "babel-plugin-istanbul": "^6.0.0",
+      "chalk": "^4.0.0",
+      "convert-source-map": "^1.4.0",
+      "fast-json-stable-stringify": "^2.0.0",
+      "graceful-fs": "^4.2.4",
+      "jest-haste-map": "^26.6.2",
+      "jest-regex-util": "^26.0.0",
+      "jest-util": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "pirates": "^4.0.1",
+      "slash": "^3.0.0",
+      "source-map": "^0.6.1",
+      "write-file-atomic": "^3.0.0"
+     }
+    },
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "babel-jest": {
+     "version": "26.6.3",
+     "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+     "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@jest/transform": "^26.6.2",
+      "@jest/types": "^26.6.2",
+      "@types/babel__core": "^7.1.7",
+      "babel-plugin-istanbul": "^6.0.0",
+      "babel-preset-jest": "^26.6.2",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "slash": "^3.0.0"
+     }
+    },
+    "babel-plugin-jest-hoist": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+     "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+     "dev": true,
+     "requires": {
+      "@babel/template": "^7.3.3",
+      "@babel/types": "^7.3.3",
+      "@types/babel__core": "^7.0.0",
+      "@types/babel__traverse": "^7.0.6"
+     }
+    },
+    "babel-preset-current-node-syntax": {
+     "version": "1.0.1",
+     "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+     "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+     "dev": true,
+     "requires": {
+      "@babel/plugin-syntax-async-generators": "^7.8.4",
+      "@babel/plugin-syntax-bigint": "^7.8.3",
+      "@babel/plugin-syntax-class-properties": "^7.8.3",
+      "@babel/plugin-syntax-import-meta": "^7.8.3",
+      "@babel/plugin-syntax-json-strings": "^7.8.3",
+      "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+      "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+      "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+      "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+      "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+      "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+      "@babel/plugin-syntax-top-level-await": "^7.8.3"
+     }
+    },
+    "babel-preset-jest": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+     "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+     "dev": true,
+     "requires": {
+      "babel-plugin-jest-hoist": "^26.6.2",
+      "babel-preset-current-node-syntax": "^1.0.0"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
     },
-    "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
-      "ansi-regex": "^5.0.0",
-      "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
      }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
+     }
+    },
+    "pretty-format": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "ansi-regex": "^5.0.0",
+      "ansi-styles": "^4.0.0",
+      "react-is": "^17.0.1"
+     }
+    },
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
+    },
+    "source-map": {
+     "version": "0.6.1",
+     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+     "dev": true
     }
    }
   },
@@ -5916,194 +6158,181 @@
    }
   },
   "jest-each": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.0.1.tgz",
-   "integrity": "sha512-OTgJlwXCAR8NIWaXFL5DBbeS4QIYPuNASkzSwMCJO+ywo9BEa6TqkaSWsfR7VdbMLdgYJqSfQcIyjJCNwl5n4Q==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+   "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "chalk": "^4.0.0",
-    "jest-get-type": "^26.0.0",
-    "jest-util": "^26.0.1",
-    "pretty-format": "^26.0.1"
+    "jest-get-type": "^26.3.0",
+    "jest-util": "^26.6.2",
+    "pretty-format": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
     },
-    "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
-      "ansi-regex": "^5.0.0",
-      "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "pretty-format": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "ansi-regex": "^5.0.0",
+      "ansi-styles": "^4.0.0",
+      "react-is": "^17.0.1"
      }
+    },
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-environment-jsdom": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.0.1.tgz",
-   "integrity": "sha512-u88NJa3aptz2Xix2pFhihRBAatwZHWwSiRLBDBQE1cdJvDjPvv7ZGA0NQBxWwDDn7D0g1uHqxM8aGgfA9Bx49g==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+   "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
    "dev": true,
    "requires": {
-    "@jest/environment": "^26.0.1",
-    "@jest/fake-timers": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "jest-mock": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jsdom": "^16.2.2"
+    "@jest/environment": "^26.6.2",
+    "@jest/fake-timers": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
+    "jest-mock": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "jsdom": "^16.4.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     }
    }
   },
   "jest-environment-node": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.0.1.tgz",
-   "integrity": "sha512-4FRBWcSn5yVo0KtNav7+5NH5Z/tEgDLp7VRQVS5tCouWORxj+nI+1tOLutM07Zb2Qi7ja+HEDoOUkjBSWZg/IQ==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+   "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
    "dev": true,
    "requires": {
-    "@jest/environment": "^26.0.1",
-    "@jest/fake-timers": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "jest-mock": "^26.0.1",
-    "jest-util": "^26.0.1"
+    "@jest/environment": "^26.6.2",
+    "@jest/fake-timers": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
+    "jest-mock": "^26.6.2",
+    "jest-util": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     }
    }
@@ -6179,386 +6408,320 @@
    }
   },
   "jest-jasmine2": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.0.1.tgz",
-   "integrity": "sha512-ILaRyiWxiXOJ+RWTKupzQWwnPaeXPIoLS5uW41h18varJzd9/7I0QJGqg69fhTT1ev9JpSSo9QtalriUN0oqOg==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+   "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
    "dev": true,
    "requires": {
     "@babel/traverse": "^7.1.0",
-    "@jest/environment": "^26.0.1",
-    "@jest/source-map": "^26.0.0",
-    "@jest/test-result": "^26.0.1",
-    "@jest/types": "^26.0.1",
+    "@jest/environment": "^26.6.2",
+    "@jest/source-map": "^26.6.2",
+    "@jest/test-result": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
     "chalk": "^4.0.0",
     "co": "^4.6.0",
-    "expect": "^26.0.1",
+    "expect": "^26.6.2",
     "is-generator-fn": "^2.0.0",
-    "jest-each": "^26.0.1",
-    "jest-matcher-utils": "^26.0.1",
-    "jest-message-util": "^26.0.1",
-    "jest-runtime": "^26.0.1",
-    "jest-snapshot": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "pretty-format": "^26.0.1",
+    "jest-each": "^26.6.2",
+    "jest-matcher-utils": "^26.6.2",
+    "jest-message-util": "^26.6.2",
+    "jest-runtime": "^26.6.3",
+    "jest-snapshot": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "pretty-format": "^26.6.2",
     "throat": "^5.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     },
     "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
+      "@jest/types": "^26.6.2",
       "ansi-regex": "^5.0.0",
       "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "react-is": "^17.0.1"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-leak-detector": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.0.1.tgz",
-   "integrity": "sha512-93FR8tJhaYIWrWsbmVN1pQ9ZNlbgRpfvrnw5LmgLRX0ckOJ8ut/I35CL7awi2ecq6Ca4lL59bEK9hr7nqoHWPA==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+   "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
    "dev": true,
    "requires": {
-    "jest-get-type": "^26.0.0",
-    "pretty-format": "^26.0.1"
+    "jest-get-type": "^26.3.0",
+    "pretty-format": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
     },
     "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
+      "@jest/types": "^26.6.2",
       "ansi-regex": "^5.0.0",
       "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "react-is": "^17.0.1"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-matcher-utils": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.0.1.tgz",
-   "integrity": "sha512-PUMlsLth0Azen8Q2WFTwnSkGh2JZ8FYuwijC8NR47vXKpsrKmA1wWvgcj1CquuVfcYiDEdj985u5Wmg7COEARw==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+   "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
    "dev": true,
    "requires": {
     "chalk": "^4.0.0",
-    "jest-diff": "^26.0.1",
-    "jest-get-type": "^26.0.0",
-    "pretty-format": "^26.0.1"
+    "jest-diff": "^26.6.2",
+    "jest-get-type": "^26.3.0",
+    "pretty-format": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "diff-sequences": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
-     "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+     "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
      "dev": true
     },
     "jest-diff": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.0.1.tgz",
-     "integrity": "sha512-odTcHyl5X+U+QsczJmOjWw5tPvww+y9Yim5xzqxVl/R1j4z71+fHW4g8qu1ugMmKdFdxw+AtQgs5mupPnzcIBQ==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+     "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
      "dev": true,
      "requires": {
       "chalk": "^4.0.0",
-      "diff-sequences": "^26.0.0",
-      "jest-get-type": "^26.0.0",
-      "pretty-format": "^26.0.1"
+      "diff-sequences": "^26.6.2",
+      "jest-get-type": "^26.3.0",
+      "pretty-format": "^26.6.2"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
     },
     "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
+      "@jest/types": "^26.6.2",
       "ansi-regex": "^5.0.0",
       "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "react-is": "^17.0.1"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-message-util": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.0.1.tgz",
-   "integrity": "sha512-CbK8uQREZ8umUfo8+zgIfEt+W7HAHjQCoRaNs4WxKGhAYBGwEyvxuK81FXa7VeB9pwDEXeeKOB2qcsNVCAvB7Q==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+   "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
    "dev": true,
    "requires": {
     "@babel/code-frame": "^7.0.0",
-    "@jest/types": "^26.0.1",
-    "@types/stack-utils": "^1.0.1",
+    "@jest/types": "^26.6.2",
+    "@types/stack-utils": "^2.0.0",
     "chalk": "^4.0.0",
     "graceful-fs": "^4.2.4",
     "micromatch": "^4.0.2",
+    "pretty-format": "^26.6.2",
     "slash": "^3.0.0",
     "stack-utils": "^2.0.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
+    "@types/istanbul-reports": {
      "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
      }
+    },
+    "pretty-format": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "ansi-regex": "^5.0.0",
+      "ansi-styles": "^4.0.0",
+      "react-is": "^17.0.1"
+     }
+    },
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-mock": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.0.1.tgz",
-   "integrity": "sha512-MpYTBqycuPYSY6xKJognV7Ja46/TeRbAZept987Zp+tuJvMN0YBWyyhG9mXyYQaU3SBI0TUlSaO5L3p49agw7Q==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+   "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1"
+    "@jest/types": "^26.6.2",
+    "@types/node": "*"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
      }
     }
    }
   },
   "jest-pnp-resolver": {
-   "version": "1.2.1",
-   "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-   "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+   "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
    "dev": true
   },
   "jest-regex-util": {
@@ -6568,181 +6731,348 @@
    "dev": true
   },
   "jest-resolve": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.0.1.tgz",
-   "integrity": "sha512-6jWxk0IKZkPIVTvq6s72RH735P8f9eCJW3IM5CX/SJFeKq1p2cZx0U49wf/SdMlhaB/anann5J2nCJj6HrbezQ==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+   "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "chalk": "^4.0.0",
     "graceful-fs": "^4.2.4",
-    "jest-pnp-resolver": "^1.2.1",
-    "jest-util": "^26.0.1",
+    "jest-pnp-resolver": "^1.2.2",
+    "jest-util": "^26.6.2",
     "read-pkg-up": "^7.0.1",
-    "resolve": "^1.17.0",
+    "resolve": "^1.18.1",
     "slash": "^3.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
+    "@types/istanbul-reports": {
      "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "resolve": {
+     "version": "1.19.0",
+     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+     "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+     "dev": true,
+     "requires": {
+      "is-core-module": "^2.1.0",
+      "path-parse": "^1.0.6"
      }
     }
    }
   },
   "jest-resolve-dependencies": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.0.1.tgz",
-   "integrity": "sha512-9d5/RS/ft0vB/qy7jct/qAhzJsr6fRQJyGAFigK3XD4hf9kIbEH5gks4t4Z7kyMRhowU6HWm/o8ILqhaHdSqLw==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+   "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "jest-regex-util": "^26.0.0",
-    "jest-snapshot": "^26.0.1"
+    "jest-snapshot": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@types/istanbul-lib-report": "*"
      }
     }
    }
   },
   "jest-runner": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.0.1.tgz",
-   "integrity": "sha512-CApm0g81b49Znm4cZekYQK67zY7kkB4umOlI2Dx5CwKAzdgw75EN+ozBHRvxBzwo1ZLYZ07TFxkaPm+1t4d8jA==",
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+   "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
    "dev": true,
    "requires": {
-    "@jest/console": "^26.0.1",
-    "@jest/environment": "^26.0.1",
-    "@jest/test-result": "^26.0.1",
-    "@jest/types": "^26.0.1",
+    "@jest/console": "^26.6.2",
+    "@jest/environment": "^26.6.2",
+    "@jest/test-result": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
     "chalk": "^4.0.0",
+    "emittery": "^0.7.1",
     "exit": "^0.1.2",
     "graceful-fs": "^4.2.4",
-    "jest-config": "^26.0.1",
+    "jest-config": "^26.6.3",
     "jest-docblock": "^26.0.0",
-    "jest-haste-map": "^26.0.1",
-    "jest-jasmine2": "^26.0.1",
-    "jest-leak-detector": "^26.0.1",
-    "jest-message-util": "^26.0.1",
-    "jest-resolve": "^26.0.1",
-    "jest-runtime": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jest-worker": "^26.0.0",
+    "jest-haste-map": "^26.6.2",
+    "jest-leak-detector": "^26.6.2",
+    "jest-message-util": "^26.6.2",
+    "jest-resolve": "^26.6.2",
+    "jest-runtime": "^26.6.3",
+    "jest-util": "^26.6.2",
+    "jest-worker": "^26.6.2",
     "source-map-support": "^0.5.6",
     "throat": "^5.0.0"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
+     }
+    },
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
+     }
+    }
+   }
+  },
+  "jest-runtime": {
+   "version": "26.6.3",
+   "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+   "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+   "dev": true,
+   "requires": {
+    "@jest/console": "^26.6.2",
+    "@jest/environment": "^26.6.2",
+    "@jest/fake-timers": "^26.6.2",
+    "@jest/globals": "^26.6.2",
+    "@jest/source-map": "^26.6.2",
+    "@jest/test-result": "^26.6.2",
+    "@jest/transform": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/yargs": "^15.0.0",
+    "chalk": "^4.0.0",
+    "cjs-module-lexer": "^0.6.0",
+    "collect-v8-coverage": "^1.0.0",
+    "exit": "^0.1.2",
+    "glob": "^7.1.3",
+    "graceful-fs": "^4.2.4",
+    "jest-config": "^26.6.3",
+    "jest-haste-map": "^26.6.2",
+    "jest-message-util": "^26.6.2",
+    "jest-mock": "^26.6.2",
+    "jest-regex-util": "^26.0.0",
+    "jest-resolve": "^26.6.2",
+    "jest-snapshot": "^26.6.2",
+    "jest-util": "^26.6.2",
+    "jest-validate": "^26.6.2",
+    "slash": "^3.0.0",
+    "strip-bom": "^4.0.0",
+    "yargs": "^15.4.1"
+   },
+   "dependencies": {
+    "@jest/transform": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+     "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+     "dev": true,
+     "requires": {
+      "@babel/core": "^7.1.0",
+      "@jest/types": "^26.6.2",
+      "babel-plugin-istanbul": "^6.0.0",
+      "chalk": "^4.0.0",
+      "convert-source-map": "^1.4.0",
+      "fast-json-stable-stringify": "^2.0.0",
+      "graceful-fs": "^4.2.4",
+      "jest-haste-map": "^26.6.2",
+      "jest-regex-util": "^26.0.0",
+      "jest-util": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "pirates": "^4.0.1",
+      "slash": "^3.0.0",
+      "source-map": "^0.6.1",
+      "write-file-atomic": "^3.0.0"
+     }
+    },
+    "@jest/types": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-coverage": "^2.0.0",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
+      "@types/yargs": "^15.0.0",
+      "chalk": "^4.0.0"
+     }
+    },
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+     "dev": true,
+     "requires": {
+      "@types/istanbul-lib-report": "*"
+     }
+    },
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
+     }
+    },
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
      }
     },
     "source-map": {
@@ -6750,108 +7080,6 @@
      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
      "dev": true
-    },
-    "source-map-support": {
-     "version": "0.5.19",
-     "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-     "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-     "dev": true,
-     "requires": {
-      "buffer-from": "^1.0.0",
-      "source-map": "^0.6.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
-   }
-  },
-  "jest-runtime": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.0.1.tgz",
-   "integrity": "sha512-Ci2QhYFmANg5qaXWf78T2Pfo6GtmIBn2rRaLnklRyEucmPccmCKvS9JPljcmtVamsdMmkyNkVFb9pBTD6si9Lw==",
-   "dev": true,
-   "requires": {
-    "@jest/console": "^26.0.1",
-    "@jest/environment": "^26.0.1",
-    "@jest/fake-timers": "^26.0.1",
-    "@jest/globals": "^26.0.1",
-    "@jest/source-map": "^26.0.0",
-    "@jest/test-result": "^26.0.1",
-    "@jest/transform": "^26.0.1",
-    "@jest/types": "^26.0.1",
-    "@types/yargs": "^15.0.0",
-    "chalk": "^4.0.0",
-    "collect-v8-coverage": "^1.0.0",
-    "exit": "^0.1.2",
-    "glob": "^7.1.3",
-    "graceful-fs": "^4.2.4",
-    "jest-config": "^26.0.1",
-    "jest-haste-map": "^26.0.1",
-    "jest-message-util": "^26.0.1",
-    "jest-mock": "^26.0.1",
-    "jest-regex-util": "^26.0.0",
-    "jest-resolve": "^26.0.1",
-    "jest-snapshot": "^26.0.1",
-    "jest-util": "^26.0.1",
-    "jest-validate": "^26.0.1",
-    "slash": "^3.0.0",
-    "strip-bom": "^4.0.0",
-    "yargs": "^15.3.1"
-   },
-   "dependencies": {
-    "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
-     "dev": true,
-     "requires": {
-      "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
-      "@types/yargs": "^15.0.0",
-      "chalk": "^4.0.0"
-     }
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "slash": {
-     "version": "3.0.0",
-     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-     "dev": true
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
     }
    }
   },
@@ -6865,116 +7093,173 @@
    }
   },
   "jest-snapshot": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.0.1.tgz",
-   "integrity": "sha512-jxd+cF7+LL+a80qh6TAnTLUZHyQoWwEHSUFJjkw35u3Gx+BZUNuXhYvDqHXr62UQPnWo2P6fvQlLjsU93UKyxA==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+   "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
    "dev": true,
    "requires": {
     "@babel/types": "^7.0.0",
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
+    "@types/babel__traverse": "^7.0.4",
     "@types/prettier": "^2.0.0",
     "chalk": "^4.0.0",
-    "expect": "^26.0.1",
+    "expect": "^26.6.2",
     "graceful-fs": "^4.2.4",
-    "jest-diff": "^26.0.1",
-    "jest-get-type": "^26.0.0",
-    "jest-matcher-utils": "^26.0.1",
-    "jest-message-util": "^26.0.1",
-    "jest-resolve": "^26.0.1",
-    "make-dir": "^3.0.0",
+    "jest-diff": "^26.6.2",
+    "jest-get-type": "^26.3.0",
+    "jest-haste-map": "^26.6.2",
+    "jest-matcher-utils": "^26.6.2",
+    "jest-message-util": "^26.6.2",
+    "jest-resolve": "^26.6.2",
     "natural-compare": "^1.4.0",
-    "pretty-format": "^26.0.1",
+    "pretty-format": "^26.6.2",
     "semver": "^7.3.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "diff-sequences": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
-     "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+     "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
      "dev": true
     },
     "jest-diff": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.0.1.tgz",
-     "integrity": "sha512-odTcHyl5X+U+QsczJmOjWw5tPvww+y9Yim5xzqxVl/R1j4z71+fHW4g8qu1ugMmKdFdxw+AtQgs5mupPnzcIBQ==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+     "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
      "dev": true,
      "requires": {
       "chalk": "^4.0.0",
-      "diff-sequences": "^26.0.0",
-      "jest-get-type": "^26.0.0",
-      "pretty-format": "^26.0.1"
+      "diff-sequences": "^26.6.2",
+      "jest-get-type": "^26.3.0",
+      "pretty-format": "^26.6.2"
      }
     },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
+    },
+    "jest-haste-map": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+     "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/graceful-fs": "^4.1.2",
+      "@types/node": "*",
+      "anymatch": "^3.0.3",
+      "fb-watchman": "^2.0.0",
+      "fsevents": "^2.1.2",
+      "graceful-fs": "^4.2.4",
+      "jest-regex-util": "^26.0.0",
+      "jest-serializer": "^26.6.2",
+      "jest-util": "^26.6.2",
+      "jest-worker": "^26.6.2",
+      "micromatch": "^4.0.2",
+      "sane": "^4.0.3",
+      "walker": "^1.0.7"
+     }
+    },
+    "jest-serializer": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+     "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "graceful-fs": "^4.2.4"
+     }
+    },
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+     "dev": true,
+     "requires": {
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
+     }
+    },
+    "jest-worker": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+     "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+     "dev": true,
+     "requires": {
+      "@types/node": "*",
+      "merge-stream": "^2.0.0",
+      "supports-color": "^7.0.0"
+     }
+    },
+    "lru-cache": {
+     "version": "6.0.0",
+     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+     "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+     "dev": true,
+     "requires": {
+      "yallist": "^4.0.0"
+     }
     },
     "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
+      "@jest/types": "^26.6.2",
       "ansi-regex": "^5.0.0",
       "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "react-is": "^17.0.1"
      }
     },
-    "semver": {
-     "version": "7.3.2",
-     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
      "dev": true
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+    "semver": {
+     "version": "7.3.4",
+     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+     "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
      "dev": true,
      "requires": {
-      "has-flag": "^4.0.0"
+      "lru-cache": "^6.0.0"
      }
+    },
+    "yallist": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+     "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+     "dev": true
     }
    }
   },
@@ -7035,145 +7320,122 @@
    }
   },
   "jest-validate": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.0.1.tgz",
-   "integrity": "sha512-u0xRc+rbmov/VqXnX3DlkxD74rHI/CfS5xaV2VpeaVySjbb1JioNVOyly5b56q2l9ZKe7bVG5qWmjfctkQb0bA==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+   "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
    "dev": true,
    "requires": {
-    "@jest/types": "^26.0.1",
+    "@jest/types": "^26.6.2",
     "camelcase": "^6.0.0",
     "chalk": "^4.0.0",
-    "jest-get-type": "^26.0.0",
+    "jest-get-type": "^26.3.0",
     "leven": "^3.1.0",
-    "pretty-format": "^26.0.1"
+    "pretty-format": "^26.6.2"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
     "camelcase": {
-     "version": "6.0.0",
-     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-     "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+     "version": "6.2.0",
+     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+     "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
      "dev": true
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-     "dev": true,
-     "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
     "jest-get-type": {
-     "version": "26.0.0",
-     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-     "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+     "version": "26.3.0",
+     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+     "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
      "dev": true
     },
     "pretty-format": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
-     "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+     "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
      "dev": true,
      "requires": {
-      "@jest/types": "^26.0.1",
+      "@jest/types": "^26.6.2",
       "ansi-regex": "^5.0.0",
       "ansi-styles": "^4.0.0",
-      "react-is": "^16.12.0"
+      "react-is": "^17.0.1"
      }
     },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
+    "react-is": {
+     "version": "17.0.1",
+     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+     "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+     "dev": true
     }
    }
   },
   "jest-watcher": {
-   "version": "26.0.1",
-   "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.0.1.tgz",
-   "integrity": "sha512-pdZPydsS8475f89kGswaNsN3rhP6lnC3/QDCppP7bg1L9JQz7oU9Mb/5xPETk1RHDCWeqmVC47M4K5RR7ejxFw==",
+   "version": "26.6.2",
+   "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+   "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
    "dev": true,
    "requires": {
-    "@jest/test-result": "^26.0.1",
-    "@jest/types": "^26.0.1",
+    "@jest/test-result": "^26.6.2",
+    "@jest/types": "^26.6.2",
+    "@types/node": "*",
     "ansi-escapes": "^4.2.1",
     "chalk": "^4.0.0",
-    "jest-util": "^26.0.1",
+    "jest-util": "^26.6.2",
     "string-length": "^4.0.1"
    },
    "dependencies": {
     "@jest/types": {
-     "version": "26.0.1",
-     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
-     "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+     "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
      "dev": true,
      "requires": {
       "@types/istanbul-lib-coverage": "^2.0.0",
-      "@types/istanbul-reports": "^1.1.1",
+      "@types/istanbul-reports": "^3.0.0",
+      "@types/node": "*",
       "@types/yargs": "^15.0.0",
       "chalk": "^4.0.0"
      }
     },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+    "@types/istanbul-reports": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+     "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
      "dev": true,
      "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
+      "@types/istanbul-lib-report": "*"
      }
     },
-    "chalk": {
-     "version": "4.1.0",
-     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+    "jest-util": {
+     "version": "26.6.2",
+     "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+     "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
      "dev": true,
      "requires": {
-      "ansi-styles": "^4.1.0",
-      "supports-color": "^7.1.0"
-     }
-    },
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
+      "@jest/types": "^26.6.2",
+      "@types/node": "*",
+      "chalk": "^4.0.0",
+      "graceful-fs": "^4.2.4",
+      "is-ci": "^2.0.0",
+      "micromatch": "^4.0.2"
      }
     }
    }
@@ -7222,9 +7484,9 @@
    "dev": true
   },
   "jsdom": {
-   "version": "16.2.2",
-   "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
-   "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+   "version": "16.4.0",
+   "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+   "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
    "dev": true,
    "requires": {
     "abab": "^2.0.3",
@@ -7247,7 +7509,7 @@
     "tough-cookie": "^3.0.1",
     "w3c-hr-time": "^1.0.2",
     "w3c-xmlserializer": "^2.0.0",
-    "webidl-conversions": "^6.0.0",
+    "webidl-conversions": "^6.1.0",
     "whatwg-encoding": "^1.0.5",
     "whatwg-mimetype": "^2.3.0",
     "whatwg-url": "^8.0.0",
@@ -7567,18 +7829,18 @@
    }
   },
   "mime-db": {
-   "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-   "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+   "version": "1.45.0",
+   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+   "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
    "dev": true
   },
   "mime-types": {
-   "version": "2.1.27",
-   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-   "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+   "version": "2.1.28",
+   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+   "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
    "dev": true,
    "requires": {
-    "mime-db": "1.44.0"
+    "mime-db": "1.45.0"
    }
   },
   "mimic-fn": {
@@ -7703,24 +7965,44 @@
    "dev": true
   },
   "node-notifier": {
-   "version": "7.0.1",
-   "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.1.tgz",
-   "integrity": "sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==",
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
+   "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
    "dev": true,
    "optional": true,
    "requires": {
     "growly": "^1.3.0",
-    "is-wsl": "^2.1.1",
-    "semver": "^7.2.1",
+    "is-wsl": "^2.2.0",
+    "semver": "^7.3.2",
     "shellwords": "^0.1.1",
-    "uuid": "^7.0.3",
+    "uuid": "^8.3.0",
     "which": "^2.0.2"
    },
    "dependencies": {
+    "lru-cache": {
+     "version": "6.0.0",
+     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+     "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+     "dev": true,
+     "optional": true,
+     "requires": {
+      "yallist": "^4.0.0"
+     }
+    },
     "semver": {
-     "version": "7.3.2",
-     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+     "version": "7.3.4",
+     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+     "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+     "dev": true,
+     "optional": true,
+     "requires": {
+      "lru-cache": "^6.0.0"
+     }
+    },
+    "yallist": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+     "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
      "dev": true,
      "optional": true
     }
@@ -7925,9 +8207,9 @@
    }
   },
   "onetime": {
-   "version": "5.1.0",
-   "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-   "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+   "version": "5.1.2",
+   "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+   "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
    "dev": true,
    "requires": {
     "mimic-fn": "^2.1.0"
@@ -7954,9 +8236,9 @@
    "dev": true
   },
   "p-each-series": {
-   "version": "2.1.0",
-   "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-   "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+   "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
    "dev": true
   },
   "p-finally": {
@@ -8539,13 +8821,13 @@
    "dev": true
   },
   "prompts": {
-   "version": "2.3.2",
-   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-   "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+   "version": "2.4.0",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+   "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
    "dev": true,
    "requires": {
     "kleur": "^3.0.3",
-    "sisteransi": "^1.0.4"
+    "sisteransi": "^1.0.5"
    }
   },
   "prop-types": {
@@ -8774,21 +9056,21 @@
    }
   },
   "request-promise-core": {
-   "version": "1.1.3",
-   "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-   "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+   "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
    "dev": true,
    "requires": {
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.19"
    }
   },
   "request-promise-native": {
-   "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-   "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+   "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
    "dev": true,
    "requires": {
-    "request-promise-core": "1.1.3",
+    "request-promise-core": "1.1.4",
     "stealthy-require": "^1.1.1",
     "tough-cookie": "^2.3.3"
    },
@@ -9358,6 +9640,24 @@
     "urix": "^0.1.0"
    }
   },
+  "source-map-support": {
+   "version": "0.5.19",
+   "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+   "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+   "dev": true,
+   "requires": {
+    "buffer-from": "^1.0.0",
+    "source-map": "^0.6.0"
+   },
+   "dependencies": {
+    "source-map": {
+     "version": "0.6.1",
+     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+     "dev": true
+    }
+   }
+  },
   "source-map-url": {
    "version": "0.4.0",
    "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -9435,9 +9735,9 @@
    }
   },
   "stack-utils": {
-   "version": "2.0.2",
-   "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-   "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+   "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
    "dev": true,
    "requires": {
     "escape-string-regexp": "^2.0.0"
@@ -9492,23 +9792,6 @@
    "requires": {
     "char-regex": "^1.0.2",
     "strip-ansi": "^6.0.0"
-   },
-   "dependencies": {
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "strip-ansi": {
-     "version": "6.0.0",
-     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-     "dev": true,
-     "requires": {
-      "ansi-regex": "^5.0.0"
-     }
-    }
    }
   },
   "string-width": {
@@ -9623,17 +9906,6 @@
    "requires": {
     "has-flag": "^4.0.0",
     "supports-color": "^7.0.0"
-   },
-   "dependencies": {
-    "supports-color": {
-     "version": "7.1.0",
-     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-     "dev": true,
-     "requires": {
-      "has-flag": "^4.0.0"
-     }
-    }
    }
   },
   "symbol-tree": {
@@ -10105,9 +10377,9 @@
    "dev": true
   },
   "uuid": {
-   "version": "7.0.3",
-   "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-   "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+   "version": "8.3.2",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+   "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
    "dev": true,
    "optional": true
   },
@@ -10118,9 +10390,9 @@
    "dev": true
   },
   "v8-to-istanbul": {
-   "version": "4.1.4",
-   "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
-   "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+   "version": "7.1.0",
+   "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
+   "integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
    "dev": true,
    "requires": {
     "@types/istanbul-lib-coverage": "^2.0.1",
@@ -10347,22 +10619,14 @@
    "dev": true
   },
   "whatwg-url": {
-   "version": "8.1.0",
-   "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
-   "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+   "version": "8.4.0",
+   "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+   "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
    "dev": true,
    "requires": {
     "lodash.sortby": "^4.7.0",
     "tr46": "^2.0.2",
-    "webidl-conversions": "^5.0.0"
-   },
-   "dependencies": {
-    "webidl-conversions": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-     "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-     "dev": true
-    }
+    "webidl-conversions": "^6.1.0"
    }
   },
   "which": {
@@ -10401,33 +10665,6 @@
     "ansi-styles": "^4.0.0",
     "string-width": "^4.1.0",
     "strip-ansi": "^6.0.0"
-   },
-   "dependencies": {
-    "ansi-regex": {
-     "version": "5.0.0",
-     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-     "dev": true
-    },
-    "ansi-styles": {
-     "version": "4.2.1",
-     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-     "dev": true,
-     "requires": {
-      "@types/color-name": "^1.1.1",
-      "color-convert": "^2.0.1"
-     }
-    },
-    "strip-ansi": {
-     "version": "6.0.0",
-     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-     "dev": true,
-     "requires": {
-      "ansi-regex": "^5.0.0"
-     }
-    }
    }
   },
   "wrappy": {
@@ -10458,9 +10695,9 @@
    }
   },
   "ws": {
-   "version": "7.3.0",
-   "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-   "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+   "version": "7.4.2",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+   "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
    "dev": true
   },
   "xml-name-validator": {
@@ -10482,9 +10719,9 @@
    "dev": true
   },
   "y18n": {
-   "version": "4.0.0",
-   "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-   "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+   "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
    "dev": true
   },
   "yallist": {
@@ -10511,9 +10748,9 @@
    }
   },
   "yargs": {
-   "version": "15.3.1",
-   "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-   "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+   "version": "15.4.1",
+   "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+   "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
    "dev": true,
    "requires": {
     "cliui": "^6.0.0",
@@ -10526,15 +10763,7 @@
     "string-width": "^4.2.0",
     "which-module": "^2.0.0",
     "y18n": "^4.0.0",
-    "yargs-parser": "^18.1.1"
-   },
-   "dependencies": {
-    "get-caller-file": {
-     "version": "2.0.5",
-     "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-     "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-     "dev": true
-    }
+    "yargs-parser": "^18.1.2"
    }
   },
   "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5618,9 +5618,9 @@
    "dev": true
   },
   "isoly": {
-   "version": "0.0.24",
-   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.24.tgz",
-   "integrity": "sha512-Uagzw4N2ZpJYqeFbzSIJ19x0vqfYVXALVbHH7tAyqe40xzs8P9LtWnbhXZz1nF5+sojBd97denLZc/naxsewcw=="
+   "version": "0.0.27",
+   "resolved": "https://registry.npmjs.org/isoly/-/isoly-0.0.27.tgz",
+   "integrity": "sha512-Iy6YklMufc0ytTMyJfWCRCgUqdCSmqCCJarA9F89nwp6BYTM9HCC91YPrBrMlN+h8O8j7aEsiC9XA53thDHkJg=="
   },
   "isstream": {
    "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "lint": "eslint '**/*.{js,ts,tsx}'",
   "fix": "eslint '**/*.{js,ts,tsx}' --fix",
   "build": "tsc -p .",
-  "test": "jest",
+  "test": "jest --maxWorkers=2",
   "test:watch": "watch jest",
   "prepare": "npm run build",
   "clean": "rm -rf dist node_modules coverage"
@@ -54,7 +54,7 @@
  "dependencies": {
   "authly": "0.1.5",
   "gracely": "0.0.33",
-  "isoly": "0.0.24"
+  "isoly": "0.0.27"
  },
  "devDependencies": {
   "@babel/core": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "eslint-config-standardize": "^0.7.1",
   "eslint-plugin-prettierx": "github:nilssonemma/eslint-plugin-prettierx#master",
   "eslint-plugin-simple-import-sort": "^7.0.0",
-  "jest": "^26",
+  "jest": "^26.6.3",
   "ts-jest": "^26.1.0",
   "typescript": "^3.9.5",
   "watch": "^1.0.2"


### PR DESCRIPTION
## Change
Bump jest to newest version. Maintain on 0.0 branch. Set max-workers to 2 to fix tests running out of memory.

## Rationale
Remove reported security flaw of jest dependency node-notifier.

## Impact
No impact, jest is only used in dev environment and for testing purposes.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
