### PR TITLE
Parity to es6 branch

### DIFF
--- a/Verifier.ts
+++ b/Verifier.ts
@@ -12,7 +12,7 @@ const algorithms = {
 export class Verifier<T extends authly.Payload> {
 	private constructor(private backends: [string, authly.Verifier<T> | undefined][]) {}
 	async verify(token: string | authly.Token | undefined): Promise<T | undefined> {
-		return this.backends.map(async ([a, v]) => await v?.verify(token, a)).find(p => p)
+		return (await Promise.all(this.backends.map(async ([a, v]) => await v?.verify(token, a)))).find(p => p)
 	}
 	add(...argument: (authly.Property.Transformer | undefined)[]): Verifier<T> {
 		this.backends.forEach(([_, b]) => b?.add(...argument))


### PR DESCRIPTION
## Change
Parity to master 0.2.3 - Implements the same changes as the changes between 0.2.0 and 0.2.3

## Rationale
To use these changes in Azure Functions backends, we need to have a commonjs module of the same code.

## Impact
No additional impact, refer to merge history of 0.2.x master branches.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
