### PR TITLE
Scheme type type

### DIFF
--- a/Card/Scheme.ts
+++ b/Card/Scheme.ts
@@ -13,7 +13,7 @@ export type Scheme =
 	| "visa"
 
 export namespace Scheme {
-	export const types = [
+	export const types: Scheme[] = [
 		"unknown",
 		"amex",
 		"dankort",


### PR DESCRIPTION
## Change
Added types array with type annotation to model.Card.Scheme.

## Rationale
Prevents us from unnecessarily casting the type where we use it.

## Impact
Type annotations don't have an impact on runtime.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
