### PR TITLE
Csc matched 0.0

### DIFF
--- a/Card/index.spec.ts
+++ b/Card/index.spec.ts
@@ -23,6 +23,7 @@ describe("Card", () => {
 			iin: "510510",
 			last4: "5100",
 			expires: [2, 22],
+			csc: "present",
 		})
 		const partialCard: model.Card.Change = {
 			pan: "5105105105105100",
@@ -43,5 +44,22 @@ describe("Card", () => {
 		const emptyCard: model.Card.Change = {}
 		const emptyCardOutput: Partial<model.Card> = model.Card.from(emptyCard)
 		expect(emptyCardOutput).toEqual({})
+	})
+	it("csc matched information tests", () => {
+		const creatable: model.Card.Creatable = {
+			pan: "4111111111111111",
+			expires: [2, 28],
+			csc: "987",
+		}
+		const card = model.Card.from(creatable)
+		const matched = model.Card.from(creatable, "matched")
+		const mismatched = model.Card.from(creatable, "mismatched")
+		const present = model.Card.from(creatable, "present")
+		expect({ ...card, csc: "matched" }).toEqual(matched)
+		expect(model.Card.is(matched)).toBeTruthy()
+		expect({ ...card, csc: "mismatched" }).toEqual(mismatched)
+		expect(model.Card.is(mismatched)).toBeTruthy()
+		expect(card).toEqual(present)
+		expect(model.Card.is(present)).toBeTruthy()
 	})
 })

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -13,6 +13,7 @@ export interface Card {
 	last4: string
 	expires: CardExpires
 	type?: CardType
+	csc?: "matched" | "mismatched" | "present"
 }
 
 export namespace Card {
@@ -25,21 +26,27 @@ export namespace Card {
 			typeof value.last4 == "string" &&
 			value.last4.length == 4 &&
 			CardExpires.is(value.expires) &&
-			(value.type == undefined || CardType.is(value.type))
+			(value.type == undefined || CardType.is(value.type)) &&
+			(value.csc == undefined || ["matched", "mismatched", "present"].includes(value.csc))
 		)
 	}
-	export function from(value: CardCreatable): Card
-	export function from(value: Change): Partial<Card>
-	export function from(value: CardCreatable | Change): Card | Partial<Card> {
+	export function from(value: CardCreatable, csc?: "matched" | "mismatched" | "present"): Card
+	export function from(value: Change, csc?: "matched" | "mismatched" | "present"): Partial<Card>
+	export function from(
+		value: CardCreatable | Change,
+		csc?: "matched" | "mismatched" | "present"
+	): Card | Partial<Card> {
 		let result: Card | Partial<Card>
-		if (CardCreatable.is(value))
+		if (CardCreatable.is(value)) {
 			result = {
 				scheme: CardPan.scheme(value.pan),
 				iin: CardPan.iin(value.pan),
 				last4: CardPan.last4(value.pan),
 				expires: value.expires,
 			}
-		else {
+			if (value.csc || csc)
+				result.csc = csc ? csc : "present"
+		} else {
 			result = {}
 			if (value.pan) {
 				result = {
@@ -50,7 +57,9 @@ export namespace Card {
 				}
 			}
 			if (value.expires)
-				result = { ...result, expires: value.expires }
+				result.expires = value.expires
+			if (value.csc || csc)
+				result.csc = csc ? csc : "present"
 		}
 		return result
 	}

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -95,12 +95,11 @@ export namespace Card {
 		export namespace Year {
 			export const is = CardExpires.Year.is
 		}
-		export type Type = CardType
-		export namespace Type {
-			export const is = CardType.is
-		}
 	}
-
+	export type Type = CardType
+	export namespace Type {
+		export const is = CardType.is
+	}
 	export type Token = CardToken
 	export namespace Token {
 		export const is = CardToken.is


### PR DESCRIPTION
## Change
Added information to model.Card about if csc matched or was present at point of conversion from model.Card.Creatable.

## Rationale
Could be useful information for merchant rule handling.

## Impact
No sensitive information saved, only strings "matched", "mismatched" or "present". No impact.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.

