### PR TITLE
Apply pan typeguard parity

### DIFF
--- a/Card/Change.ts
+++ b/Card/Change.ts
@@ -1,6 +1,7 @@
 import * as gracely from "gracely"
 import { Creatable } from "./Creatable"
 import { Expires } from "./Expires"
+import { Pan } from "./Pan"
 
 export type Change = Partial<Creatable>
 
@@ -8,7 +9,7 @@ export namespace Change {
 	export function is(value: Change | any): value is Change {
 		return (
 			typeof value == "object" &&
-			(value.pan == undefined || typeof value.pan == "string") &&
+			(value.pan == undefined || Pan.is(value.pan)) &&
 			(value.expires == undefined || Expires.is(value.expires)) &&
 			(value.csc == undefined || typeof value.csc == "string") &&
 			(value.verification == undefined ||
@@ -31,7 +32,7 @@ export namespace Change {
 				typeof value != "object"
 					? undefined
 					: ([
-							value.pan == undefined || typeof value.pan == "string" || { property: "pan", type: "string | undefined" },
+							value.pan == undefined || Pan.is(value.pan) || { property: "pan", type: "string | undefined" },
 							value.expires == undefined ||
 								Expires.is(value.expires) || { property: "expires", type: "string | undefined" },
 							value.csc == undefined || typeof value.csc == "string" || { property: "csc", type: "string | undefined" },

--- a/Card/Creatable.ts
+++ b/Card/Creatable.ts
@@ -13,7 +13,7 @@ export namespace Creatable {
 	export function is(value: Creatable | any): value is Creatable {
 		return (
 			typeof value == "object" &&
-			typeof value.pan == "string" &&
+			Pan.is(value.pan) &&
 			Expires.is(value.expires) &&
 			(value.csc == undefined || typeof value.csc == "string") &&
 			(value.verification == undefined ||

--- a/Card/Pan.spec.ts
+++ b/Card/Pan.spec.ts
@@ -1,5 +1,6 @@
 import * as model from "../index"
 
 describe("Card.Pan", () => {
+	it("Typeguard", () => expect(model.Card.Pan.is("5105105105105100")).toEqual(true))
 	it("last4", () => expect(model.Card.Pan.last4("5105105105105100")).toEqual("5100"))
 })


### PR DESCRIPTION
## Change
Add Pan typeguard to get better error feedback in case of incorrect PAN.

## Rationale
Currently, an incorrect PAN can in some cases be passed until 3ds enrolled requests, which leads to incorrect error statements.

## Impact
No additional impact


## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
