### PR TITLE
Added optional version parameter for method callbacks

### DIFF
--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -31,7 +31,12 @@ export namespace Token {
 						typeof value.verification.data == "object")))
 		)
 	}
-	export function getVerificationTarget(token: Token, baseUrl: string, parent: string): string {
+	export function getVerificationTarget(
+		token: Token,
+		baseUrl: string,
+		parent: string,
+		version?: "2.1.0" | "2.2.0"
+	): string {
 		return (
 			baseUrl +
 			"/card/" +
@@ -39,7 +44,8 @@ export namespace Token {
 			token.expires[0].toString().padStart(2, "0") +
 			token.expires[1].toString().padStart(2, "0") +
 			"/verification?mode=iframe&parent=" +
-			parent
+			parent +
+			(version ? `&v=${version}` : "")
 		)
 	}
 	const transformers = [


### PR DESCRIPTION
## Change
Added optional version parameter for method notification url:s. 

## Rationale
Needed to enforce 3dv2 auth version when some 3d secure related server doesn't support one version or the other.

## Impact
No impact.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
