### PR TITLE
Export scheme type array - parity

### DIFF
--- a/Card/index.ts
+++ b/Card/index.ts
@@ -82,6 +82,7 @@ export namespace Card {
 	}
 	export type Scheme = CardScheme
 	export namespace Scheme {
+		export const types = CardScheme.types
 		export const is = CardScheme.is
 	}
 	export type Expires = CardExpires


### PR DESCRIPTION
## Change
Exports the type array.

## Rationale
Needed to keep parity between the branches

## Impact
No additional impact

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
